### PR TITLE
Fix import errors for pure, <*, foldMap, mappend, and others.

### DIFF
--- a/core/src/Network/Google/Data/JSON.hs
+++ b/core/src/Network/Google/Data/JSON.hs
@@ -31,6 +31,7 @@ module Network.Google.Data.JSON
     , (.!=)
     ) where
 
+import           Control.Applicative (pure, (<$>))
 import           Data.Aeson
 import           Data.Aeson.Types
 import           Data.Data

--- a/core/src/Network/Google/Data/Numeric.hs
+++ b/core/src/Network/Google/Data/Numeric.hs
@@ -14,7 +14,6 @@ module Network.Google.Data.Numeric
     ( Nat (..)
     ) where
 
-import           Control.Lens
 import           Control.Monad
 import           Data.Aeson
 import           Data.Data
@@ -26,6 +25,7 @@ import           Data.Text.Lazy.Builder     (Builder)
 import qualified Data.Text.Lazy.Builder     as Build
 import qualified Data.Text.Lazy.Builder.Int as Build
 import qualified Data.Text.Read             as Read
+import           Data.Monoid                (mappend)
 import           Numeric.Natural
 import           Servant.API
 

--- a/core/src/Network/Google/Data/Time.hs
+++ b/core/src/Network/Google/Data/Time.hs
@@ -20,6 +20,7 @@ module Network.Google.Data.Time
     , _DateTime
     ) where
 
+import           Control.Applicative    (pure, (<*))
 import           Control.Lens
 import           Data.Aeson
 import           Data.Aeson.Encode

--- a/core/src/Network/Google/Types.hs
+++ b/core/src/Network/Google/Types.hs
@@ -25,7 +25,7 @@ module Network.Google.Types where
 
 import           Control.Applicative
 import           Control.Exception.Lens                (exception)
-import           Control.Lens                          hiding (coerce)
+import           Control.Lens
 import           Control.Monad.Catch
 import           Control.Monad.Trans.Resource
 import           Data.Aeson
@@ -39,11 +39,10 @@ import qualified Data.Conduit.List                     as CL
 import           Data.Data
 import           Data.DList                            (DList)
 import qualified Data.DList                            as DList
-import           Data.Foldable                         (foldl')
+import           Data.Foldable                         (foldl', foldMap)
 import           Data.Monoid
 import           Data.String
 import           Data.Text                             (Text)
-import qualified Data.Text                             as Text
 import qualified Data.Text.Encoding                    as Text
 import           Data.Text.Lazy.Builder                (Builder)
 import qualified Data.Text.Lazy.Builder                as Build


### PR DESCRIPTION
  * Add missing import statements.
  * Remove redundant import statements in a few cases.

I'm running GHC 7.8.4 - I have a feeling that might be why I'm getting these import errors. Are you running a later version? (7.10?). There are still a bunch of "Unrecognized pragma warnings" for the `{-# OVERLAPPING #-}` and `{-# OVERLAPPABLE #-}` pragmas.