### PR TITLE
Hack to fix a bug that caused BigQuery connections to fail.

### DIFF
--- a/gogol/src/Network/Google/Auth.hs
+++ b/gogol/src/Network/Google/Auth.hs
@@ -183,6 +183,6 @@ authorize rq s l m = bearer <$> getToken s l m
     bearer t = rq
         { Client.requestHeaders =
             ( hAuthorization
-            , toHeader (_tokenAccess t)
+            , "Bearer " <> toHeader (_tokenAccess t)
             ) : Client.requestHeaders rq
         }

--- a/gogol/src/Network/Google/Internal/Auth.hs
+++ b/gogol/src/Network/Google/Internal/Auth.hs
@@ -178,7 +178,7 @@ newtype OAuthCode = OAuthCode Text
 
 instance ToHttpApiData OAuthCode where
     toQueryParam (OAuthCode c) = c
-    toHeader     (OAuthCode c) = "Bearer " <> Text.encodeUtf8 c
+    toHeader     (OAuthCode c) = Text.encodeUtf8 c
 
 -- | An error thrown when attempting to read AuthN/AuthZ information.
 data AuthError


### PR DESCRIPTION
BigQuery connections were failing with `Invalid Credentials`, and the failing request had an authorization header that was missing the `Bearer ` prefix.

This fixes the problem in BigQuery, but the real problem is probably that instances of `ToHttpApiData` for other types of tokens are not adding the `Bearer ` prefix.