### PR TITLE
added offline mode and save/refresh FromClient-constructed Credentials functions

### DIFF
--- a/gogol/src/Network/Google/Internal/Auth.hs
+++ b/gogol/src/Network/Google/Internal/Auth.hs
@@ -127,14 +127,14 @@ data AuthorizedUser = AuthorizedUser
     { _userId      :: !ClientId
     , _userRefresh :: !RefreshToken
     , _userSecret  :: !Secret
-    } deriving (Eq, Show, Generic)
+    } deriving (Eq, Show)
 
 instance ToJSON AuthorizedUser where
-    toEncoding (AuthorizedUser i r s) =
-        pairs (  "client_id"     .= i
-              <> "refresh_token" .= r
-              <> "client_secret" .= s
-              )
+    toJSON (AuthorizedUser i r s) =
+        object [ "client_id"     .= i
+               , "refresh_token" .= r
+               , "client_secret" .= s
+               ]
 
 instance FromJSON AuthorizedUser where
     parseJSON = withObject "authorized_user" $ \o -> AuthorizedUser

--- a/gogol/src/Network/Google/Internal/Auth.hs
+++ b/gogol/src/Network/Google/Internal/Auth.hs
@@ -127,7 +127,14 @@ data AuthorizedUser = AuthorizedUser
     { _userId      :: !ClientId
     , _userRefresh :: !RefreshToken
     , _userSecret  :: !Secret
-    } deriving (Eq, Show)
+    } deriving (Eq, Show, Generic)
+
+instance ToJSON AuthorizedUser where
+    toEncoding (AuthorizedUser i r s) =
+        pairs (  "client_id"     .= i
+              <> "refresh_token" .= r
+              <> "client_secret" .= s
+              )
 
 instance FromJSON AuthorizedUser where
     parseJSON = withObject "authorized_user" $ \o -> AuthorizedUser
@@ -175,12 +182,13 @@ instance ToHttpApiData (OAuthCode s) where
     toQueryParam (OAuthCode c) = c
     toHeader     (OAuthCode c) = Text.encodeUtf8 c
 
--- | An error thrown when attempting to read AuthN/AuthZ information.
+-- | An error thrown when attempting to read/write AuthN/AuthZ information.
 data AuthError
     = RetrievalError    HttpException
     | MissingFileError  FilePath
     | InvalidFileError  FilePath Text
     | TokenRefreshError Status Text (Maybe Text)
+    | FileExistError    FilePath
       deriving (Show, Typeable)
 
 instance Exception AuthError


### PR DESCRIPTION
I added the several functions to save/refresh FromClient-constructed `Credentials`. 

After initial authorization, an `accessToken` can be refresh by `refreshStore`. As well as, it can be converted to `AuthorizedUser` and saved. Next time, users can read it directly.

Moreover, I added an `assess_type` param to form URL. 