### PR TITLE
Change Duration FromHttpApiData instance. Append s symbol to the end.

### DIFF
--- a/core/src/Network/Google/Data/Time.hs
+++ b/core/src/Network/Google/Data/Time.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -22,6 +23,7 @@ module Network.Google.Data.Time
     , _Duration
     ) where
 
+import           Data.Monoid                      ((<>))
 import           Control.Lens
 import           Data.Aeson
 import qualified Data.Aeson.Types                  as Aeson
@@ -86,7 +88,7 @@ _Duration = iso unDuration Duration
 instance ToHttpApiData Duration where
     toQueryParam =
           LText.toStrict
-        . Build.toLazyText
+        . (\seconds -> Build.toLazyText seconds <> "s")
         . Sci.formatScientificBuilder Sci.Fixed (Just 9)
         . unDuration
 


### PR DESCRIPTION
Google in [LogEntry](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) documentation explain that duration have to end with s.
 A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
[Here](https://gist.github.com/d61h6k4/5274d64c44c766218ca706104a87ae2d) example what is the behaviour is now. Pull request is fix that.