### PR TITLE
gogol: bound conduit due to loss of Resumable

### DIFF
--- a/gogol/gogol.cabal
+++ b/gogol/gogol.cabal
@@ -60,7 +60,7 @@ library
         , base                 >= 4.7 && < 5
         , bytestring           >= 0.9
         , case-insensitive     >= 1.2
-        , conduit              >= 1.1
+        , conduit              >= 1.1 && < 1.3.0
         , conduit-extra        >= 1.1
         , cryptonite           >= 0.6
         , directory            >= 1.2


### PR DESCRIPTION
Conduit 1.3.0 removed `Resumable`, leading to build failures against `1.3.0` saying `ResumableSource` could not be found. This bound avoids those failures.