### PR TITLE
Fix import conflicts for servant 0.13.

### DIFF
--- a/core/src/Network/Google/Prelude.hs
+++ b/core/src/Network/Google/Prelude.hs
@@ -27,7 +27,7 @@ import GHC.Generics        as Export (Generic)
 import Network.HTTP.Client as Export (RequestBody)
 import Numeric.Natural     as Export (Natural)
 import Prelude             as Export hiding (product)
-import Servant.API         as Export hiding (Headers, Link, getResponse)
+import Servant.API         as Export hiding (Headers, Link, getResponse, Stream)
 import Servant.Utils.Links as Export hiding (Link)
 import Web.HttpApiData     as Export (FromHttpApiData (..), ToHttpApiData (..))
 

--- a/core/src/Network/Google/Types.hs
+++ b/core/src/Network/Google/Types.hs
@@ -53,7 +53,7 @@ import           Network.HTTP.Client          (HttpException, RequestBody (..))
 import           Network.HTTP.Media           hiding (Accept)
 import           Network.HTTP.Types           hiding (Header)
 import qualified Network.HTTP.Types           as HTTP
-import           Servant.API
+import           Servant.API                  hiding (Stream)
 import           Web.HttpApiData
 
 data AltJSON   = AltJSON   deriving (Eq, Ord, Show, Read, Generic, Typeable)


### PR DESCRIPTION
`servant-0.13` introduces it's own `Stream` type. I'm not sure if you prefer CPP for the `hiding` (so there are no warnings for versions earlier than 0.13) - if so, let me know, and I'm happy to change it.