### PR TITLE
gogol: bound conduit due to loss of Resumable take 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cabal.config
 # Dirs
 .cabal-sandbox
 dist
+dist-newstyle
 vendor
 .vagrant.d
 .stack-work

--- a/core/gogol-core.cabal
+++ b/core/gogol-core.cabal
@@ -50,7 +50,7 @@ library
         , bifunctors           >= 0.1
         , bytestring           >= 0.9
         , case-insensitive     >= 1.2
-        , conduit              >= 1.1
+        , conduit              >= 1.1 && < 1.3
         , dlist                >= 0.7
         , exceptions           >= 0.6
         , hashable             >= 1.2

--- a/core/src/Network/Google/Types.hs
+++ b/core/src/Network/Google/Types.hs
@@ -312,6 +312,7 @@ instance Semigroup Request where
 
 instance Monoid Request where
     mempty      = Request mempty mempty mempty mempty
+    mappend     = (<>)
 
 appendPath :: Request -> Builder -> Request
 appendPath rq x = rq { _rqPath = _rqPath rq <> "/" <> x }

--- a/core/src/Network/Google/Types.hs
+++ b/core/src/Network/Google/Types.hs
@@ -303,13 +303,15 @@ data Request = Request
     , _rqBody    :: ![Body]
     }
 
-instance Monoid Request where
-    mempty      = Request mempty mempty mempty mempty
-    mappend a b = Request
+instance Semigroup Request where
+    a <> b = Request
         (_rqPath    a <> "/" <> _rqPath b)
         (_rqQuery   a <> _rqQuery b)
         (_rqHeaders a <> _rqHeaders b)
         (_rqBody    b <> _rqBody a)
+
+instance Monoid Request where
+    mempty      = Request mempty mempty mempty mempty
 
 appendPath :: Request -> Builder -> Request
 appendPath rq x = rq { _rqPath = _rqPath rq <> "/" <> x }


### PR DESCRIPTION
the same issue of [#95 gogol: bound conduit due to loss of Resumable](https://github.com/brendanhay/gogol/pull/95)

When I build the gogol core, cabal complains

```
src/Network/Google/Types.hs:306:10: error:
    • No instance for (Semigroup Request)
        arising from the superclasses of an instance declaration
    • In the instance declaration for ‘Monoid Request’
    |
306 | instance Monoid Request where
    |          ^^^^^^^^^^^^^^
cabal: Failed to build gogol-core-0.3.0 (which is required by test:tests from
gogol-core-0.3.0).
```
Since base-4.11.0.0, Semigroup is the superclass of Monoid. I moved `mappend` definition as the instance of `Semigroup`