### PR TITLE
nix: add nixpkgs for building gen

### DIFF
--- a/gen/stack.yaml
+++ b/gen/stack.yaml
@@ -10,3 +10,7 @@ extra-deps:
 
 packages:
   - '.'
+
+nix:
+  enable: true
+  packages: [zlib, icu]


### PR DESCRIPTION
This allows me to build without adding these to my user environment under NixOS. I am not very familiar with Stack+Nix so I followed this documentation:
https://docs.haskellstack.org/en/stable/nix_integration/

If the `shell.nix` route is preferable I can generate that instead, feedback is welcome!