### PR TITLE
Fix build of core with base-4.11.0

### DIFF
--- a/core/src/Network/Google/Types.hs
+++ b/core/src/Network/Google/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
@@ -310,11 +311,21 @@ data Request = Request
 
 instance Monoid Request where
     mempty      = Request mempty mempty mempty mempty
+#if !MIN_VERSION_base(4,11,0)
     mappend a b = Request
         (_rqPath    a <> "/" <> _rqPath b)
         (_rqQuery   a <> _rqQuery b)
         (_rqHeaders a <> _rqHeaders b)
         (_rqBody    b <> _rqBody a)
+#else
+instance Semigroup Request where
+    a <> b = Request
+        (_rqPath    a <> "/" <> _rqPath b)
+        (_rqQuery   a <> _rqQuery b)
+        (_rqHeaders a <> _rqHeaders b)
+        (_rqBody    b <> _rqBody a)
+
+#endif
 
 appendPath :: Request -> Builder -> Request
 appendPath rq x = rq { _rqPath = _rqPath rq <> "/" <> x }


### PR DESCRIPTION
This is backwards-compatible and although there is no full ghc-8.4.3
and lts-12.9 support yet, this is useful for projects that mix in
gogol.