### PR TITLE
Fix build of core with base-4.11.0

### DIFF
--- a/core/src/Network/Google/Types.hs
+++ b/core/src/Network/Google/Types.hs
@@ -305,7 +305,10 @@ data Request = Request
 
 instance Monoid Request where
     mempty      = Request mempty mempty mempty mempty
-    mappend a b = Request
+    mappend     = (<>)
+
+instance Semigroup Request where
+    a <> b = Request
         (_rqPath    a <> "/" <> _rqPath b)
         (_rqQuery   a <> _rqQuery b)
         (_rqHeaders a <> _rqHeaders b)


### PR DESCRIPTION
This is backwards-compatible and although there is no full ghc-8.4.3
and lts-12.9 support yet, this is useful for projects that mix in
gogol.