### PR TITLE
Upgraded gogol-gen to work with lts-13 (ghc-8.6.3)

### DIFF
--- a/gen/gogol-gen.cabal
+++ b/gen/gogol-gen.cabal
@@ -55,12 +55,12 @@ executable gogol-gen
         , errors           >= 2.1.2
         , formatting
         , hashable
-        , haskell-src-exts == 1.17.1
-        , hindent          == 4.6.4
+        , haskell-src-exts == 1.20.3
+        , hindent          == 5.2.7
         , lens
         , mtl
         , optparse-applicative
-        , pandoc < 2.0
+        , pandoc
         , parsec
         , semigroups
         , system-fileio

--- a/gen/src/Gen/AST/Flatten.hs
+++ b/gen/src/Gen/AST/Flatten.hs
@@ -1,14 +1,10 @@
 {-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TupleSections              #-}
 
 -- Module      : Gen.AST.Flatten
@@ -136,7 +132,7 @@ resource :: Map Local (Param Global)
          -> Resource (Fix Schema)
          -> AST (Resource Global)
 resource qs suf g r@Resource {..} = do
-    rs <- Map.traverseWithKey (\l -> resource qs suf (reference g l)) _rResources
+    rs <- Map.traverseWithKey (resource qs suf . reference g) _rResources
     ms <- traverse (method qs suf) _rMethods
     pure $! r
         { _rResources = rs

--- a/gen/src/Gen/AST/Render.hs
+++ b/gen/src/Gen/AST/Render.hs
@@ -1,14 +1,10 @@
 {-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE ViewPatterns               #-}
 
 -- Module      : Gen.AST.Render
@@ -25,9 +21,9 @@ module Gen.AST.Render
 import           Control.Applicative
 import           Control.Error
 import           Control.Lens                 hiding (enum, lens)
-import qualified Data.ByteString.Char8              as C8
-import qualified Data.ByteString.Lazy.Char8         as LBS
+import qualified Data.ByteString.Char8        as C8
 import qualified Data.ByteString.Lazy.Builder as LBB
+import qualified Data.ByteString.Lazy.Char8   as LBS
 import           Data.Char                    (isSpace)
 import qualified Data.HashMap.Strict          as Map
 import           Data.Maybe
@@ -136,7 +132,7 @@ renderMethod s root suf m@Method {..} = do
     x@Solved {..} <- getSolved typ
     d'            <- renderSchema x
     d <- case d' of
-      Nothing -> error "failed to render the schema"
+      Nothing  -> error "failed to render the schema"
       Just d'' -> pure d''
 
     i   <- pp Print $ requestDecl  _unique _prefix alias url (props _schema) m

--- a/gen/src/Gen/AST/Solve.hs
+++ b/gen/src/Gen/AST/Solve.hs
@@ -1,14 +1,9 @@
 {-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RankNTypes                 #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE ViewPatterns               #-}
 
 -- Module      : Gen.AST.Solve
@@ -94,7 +89,7 @@ getType g = loc "getType" g $ memo typed g go
         --- FIXME: add natural/numeric manipulations
         SLit _ l       -> res (TLit l)
         SEnm {}        -> res (TType g)
-        SArr _ (Arr e) -> (TList <$> (getType e)) >>= pure . may
+        SArr _ (Arr e) -> may <$> (TList <$> getType e)
         SObj {}        -> res (TType g)
         SRef _ r
             | ref r /= g -> req <$> getType (ref r)
@@ -195,7 +190,7 @@ overlap :: (Eq a, Hashable a) => Set a -> Set a -> Bool
 overlap xs ys = not . Set.null $ Set.intersection xs ys
 
 acronymPrefixes :: Global -> [CI Text]
-acronymPrefixes (global -> renameSpecial -> g) =
+acronymPrefixes (global -> (renameSpecial -> g)) =
     filter (/= full) $ map CI.mk (xs ++ map suffix ys ++ zs)
   where
     -- Take the next char

--- a/gen/src/Gen/Formatting.hs
+++ b/gen/src/Gen/Formatting.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE OverloadedStrings #-}
-
 -- Module      : Gen.Formatting
 -- Copyright   : (c) 2015-2016 Brendan Hay
 -- License     : Mozilla Public License, v. 2.0.

--- a/gen/src/Gen/IO.hs
+++ b/gen/src/Gen/IO.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections     #-}
 
 -- Module      : Gen.IO
 -- Copyright   : (c) 2015-2016 Brendan Hay
@@ -27,13 +26,14 @@ import           System.IO
 
 import           UnexceptionalIO           (fromIO, runUIO)
 
+import qualified Data.Text                 as Text
 import qualified Data.Text.Lazy            as LText
 import qualified Data.Text.Lazy.IO         as LText
 import qualified Filesystem                as FS
 import qualified Text.EDE                  as EDE
 
 run :: ExceptT Error IO a -> IO a
-run = runScript . fmapLT LText.unpack
+run = runScript . fmapLT (Text.pack . LText.unpack)
 
 io :: MonadIO m => IO a -> ExceptT Error m a
 io = ExceptT . fmap (first (LText.pack . show)) . liftIO . runUIO . fromIO

--- a/gen/src/Gen/Orphans.hs
+++ b/gen/src/Gen/Orphans.hs
@@ -16,8 +16,8 @@ import           Data.String
 import           Language.Haskell.Exts.Build
 import           Language.Haskell.Exts.Syntax
 
-instance Hashable Name
+instance Hashable l => Hashable (Name l)
 
-instance IsString Name  where fromString = name
-instance IsString QName where fromString = UnQual . name
-instance IsString QOp   where fromString = op . sym
+instance IsString (Name ())  where fromString = name
+instance IsString (QName ()) where fromString = UnQual () . name
+instance IsString (QOp ())   where fromString = op . sym

--- a/gen/src/Gen/Syntax.hs
+++ b/gen/src/Gen/Syntax.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections     #-}
 {-# LANGUAGE ViewPatterns      #-}
 
 -- Module      : Gen.Syntax
@@ -335,7 +334,7 @@ googleRequestDecl n assoc extras pre api url m pat prec =
 
     decls = BDecls ()
         [ patBind pat $
-            appFun (var "buildClient") $
+            appFun (var "buildClient")
                 [ ExpTypeSig () (var "Proxy") $
                     TyApp () (TyCon () "Proxy") (TyCon () (UnQual () api))
                 , var "mempty"
@@ -425,7 +424,7 @@ wildcardD f n enc x = \case
     prec = PRec () (UnQual () (dname' n)) [PFieldWildcard ()]
 
 defJS :: Local -> Exp () -> Exp ()
-defJS n x = infixApp (infixApp (var "o") ".:?" (fstr n)) ".!=" x
+defJS n = infixApp (infixApp (var "o") ".:?" (fstr n)) ".!="
 
 reqJS :: Local -> Exp ()
 reqJS = infixApp (var "o") ".:" . fstr
@@ -449,7 +448,7 @@ seqE l (r:rs) = infixApp l "<$>" (infixE r "<*>" rs)
 
 objDecl :: Global -> Prefix -> [Derive] -> Map Local Solved -> Decl ()
 objDecl n p ds rs =
-    DataDecl () arity Nothing (DHead () (dname n)) [conDecl (dname' n) p rs] [(der ds)]
+    DataDecl () arity Nothing (DHead () (dname n)) [conDecl (dname' n) p rs] [der ds]
   where
     arity | Map.size rs == 1 = NewType ()
           | otherwise        = DataType ()
@@ -620,9 +619,9 @@ mapping :: TType -> Exp () -> Exp ()
 mapping t e = infixE e "." (go t)
   where
     go = \case
-        TMaybe x@(TList {}) -> var "_Default" : go x
-        TMaybe x            -> nest (go x)
-        x                   -> maybeToList (iso x)
+        TMaybe x@TList {} -> var "_Default" : go x
+        TMaybe x          -> nest (go x)
+        x                 -> maybeToList (iso x)
 
     nest []     = []
     nest (x:xs) = [app (var "mapping") (infixE x "." xs)]

--- a/gen/src/Gen/Syntax.hs
+++ b/gen/src/Gen/Syntax.hs
@@ -26,39 +26,38 @@ import           Gen.Text
 import           Gen.Types
 import           Language.Haskell.Exts.Build  (app, appFun, infixApp, lamE, listE, name, noBinds, paren, patBind, pvar, sfun, strE, sym,
                                                var)
-import           Language.Haskell.Exts.SrcLoc
 import           Language.Haskell.Exts.Syntax hiding (Alt, Int, Lit)
 
-serviceSig :: Name -> Decl
-serviceSig n = TypeSig noLoc [n] (TyCon "ServiceConfig")
+serviceSig :: Name () -> Decl ()
+serviceSig n = TypeSig () [n] (TyCon () "ServiceConfig")
 
-serviceDecl :: Service a -> Name -> Decl
-serviceDecl s n = sfun noLoc n [] (UnGuardedRhs rhs) noBinds
+serviceDecl :: Service a -> Name () -> Decl ()
+serviceDecl s n = sfun n [] (UnGuardedRhs () rhs) noBinds
   where
     rhs = appFun (var "defaultService")
         [ app (var "ServiceId") (str (s ^. dId))
         , str . stripSuffix "/" $ stripPrefix "https://" (s ^. dRootUrl)
         ]
 
-scopeSig :: Name -> Text -> Decl
-scopeSig n v = TypeSig noLoc [n] $
-    TyApp (TyCon "Proxy") $
-        TyPromoted $ PromotedList True
-            [ TyPromoted $ PromotedString (Text.unpack v)
+scopeSig :: Name () -> Text -> Decl ()
+scopeSig n v = TypeSig () [n] $
+    TyApp () (TyCon () "Proxy") $
+        TyPromoted () $ PromotedList () True
+            [ TyPromoted () $ PromotedString () (Text.unpack v) (Text.unpack v)
             ]
 
-scopeDecl :: Name -> Decl
-scopeDecl n = sfun noLoc n [] (UnGuardedRhs (var "Proxy")) noBinds
+scopeDecl :: Name () -> Decl ()
+scopeDecl n = sfun n [] (UnGuardedRhs () (var "Proxy")) noBinds
 
-apiAlias :: Name -> [Name] -> Decl
-apiAlias n ls = TypeDecl noLoc n [] alias
+apiAlias :: Name () -> [Name ()] -> Decl ()
+apiAlias n ls = TypeDecl () (DHead () n) alias
   where
-    alias = case map (TyCon . UnQual) ls of
-        []   -> unit_tycon
-        x:xs -> foldl' (\l r -> TyInfix l (UnQual (sym ":<|>")) r) x xs
+    alias = case map (TyCon () . UnQual ()) ls of
+        []   -> unit_tycon ()
+        x:xs -> foldl' (\l r -> TyInfix () l ((UnpromotedName () . UnQual ()) (sym ":<|>")) r) x xs
 
-verbAlias :: HasDescription a s => a -> Name -> Method Solved -> Decl
-verbAlias d n m = TypeDecl noLoc n [] $ servantOr meta (catMaybes [down, up])
+verbAlias :: HasDescription a s => a -> Name () -> Method Solved -> Decl ()
+verbAlias d n m = TypeDecl () (DHead () n) $ servantOr meta (catMaybes [down, up])
   where
     meta = path  $  metadataAlias m
     down = path <$> downloadAlias m
@@ -68,18 +67,18 @@ verbAlias d n m = TypeDecl noLoc n [] $ servantOr meta (catMaybes [down, up])
 
     root = subPaths (d ^. dServicePath) ++ requestPath m (_mPath m)
 
-metadataAlias :: Method Solved -> Type
+metadataAlias :: Method Solved -> Type ()
 metadataAlias m = servantSub (jsonVerb m) (params ++ media)
   where
     params = requestQuery m (requestQueryParams m)
     media  = case _mRequest m of
         Nothing -> []
         Just b  ->
-            [ TyApp (TyApp (TyCon "ReqBody") jsonMedia)
+            [ TyApp () (TyApp () (TyCon () "ReqBody") jsonMedia)
                     (tycon (ref b))
             ]
 
-downloadAlias :: Method Solved -> Maybe Type
+downloadAlias :: Method Solved -> Maybe (Type ())
 downloadAlias m
     | _mSupportsMediaDownload m = Just download
     | otherwise                 = Nothing
@@ -88,7 +87,7 @@ downloadAlias m
 
     params = requestQuery m . Map.delete "alt" $ requestQueryParams m
 
-uploadAlias :: [Type] -> Method Solved -> Maybe Type
+uploadAlias :: [Type ()] -> Method Solved -> Maybe (Type ())
 uploadAlias sub m
     | _mSupportsMediaUpload m = Just upload
     | otherwise               = Nothing
@@ -104,16 +103,16 @@ uploadAlias sub m
     media = case _mRequest m of
         Just b ->
             [ multipartParam
-            , TyApp (TyApp (TyCon "MultipartRelated") jsonMedia)
+            , TyApp () (TyApp () (TyCon () "MultipartRelated") jsonMedia)
                     (tycon (ref b))
             ]
 
         Nothing ->
             [ mediaParam
-            , TyCon "AltMedia"
+            , TyCon () "AltMedia"
             ]
 
-requestPath :: Method Solved -> Text -> [Type]
+requestPath :: Method Solved -> Text -> [Type ()]
 requestPath m = map go . extractPath
   where
     go (Left  t)      = sing t
@@ -121,29 +120,29 @@ requestPath m = map go . extractPath
         Nothing -> error $ "Unable to find path parameter " ++ show l
         Just x  -> case c of
             Nothing | x ^. iRepeated ->
-                TyApp (TyApp (TyCon "Captures")
+                TyApp () (TyApp () (TyCon () "Captures")
                              (sing (local l)))
                       (terminalType (_type (_pParam x)))
 
             Nothing ->
-                TyApp (TyApp (TyCon "Capture")
+                TyApp () (TyApp () (TyCon () "Capture")
                              (sing (local l)))
                       (terminalType (_type (_pParam x)))
 
             Just y  ->
-                TyApp (TyApp (TyApp (TyCon "CaptureMode")
+                TyApp () (TyApp () (TyApp () (TyCon () "CaptureMode")
                                     (sing (local l)))
                              (sing y))
                       (terminalType (_type (_pParam x)))
 
-requestQuery :: Method Solved -> Map Local (Param Solved) -> [Type]
+requestQuery :: Method Solved -> Map Local (Param Solved) -> [Type ()]
 requestQuery m xs = mapMaybe go $
     orderParams fst (Map.toList xs) (_mParameterOrder m)
   where
     go (k, x) = case _pLocation x of
         Query | x ^. iRepeated
-               -> Just $ TyApp (TyApp (TyCon "QueryParams") n) t
-        Query  -> Just $ TyApp (TyApp (TyCon "QueryParam")  n) t
+               -> Just $ TyApp () (TyApp () (TyCon () "QueryParams") n) t
+        Query  -> Just $ TyApp () (TyApp () (TyCon () "QueryParam")  n) t
         Path   -> Nothing
       where
         t = terminalType (_type (_pParam x))
@@ -152,52 +151,47 @@ requestQuery m xs = mapMaybe go $
 requestQueryParams :: Method a -> Map Local (Param a)
 requestQueryParams = Map.filter ((/= Path) . _pLocation) . _mParameters
 
-servantOr, servantSub :: Type -> [Type] -> Type
-servantOr  = foldl' (\l r -> TyInfix l (UnQual (sym ":<|>")) r)
-servantSub = foldr' (\l r -> TyInfix l (UnQual (sym ":>")) r)
+servantOr, servantSub :: Type () -> [Type ()] -> Type ()
+servantOr  = foldl' (\l r -> TyInfix () l ((UnpromotedName () . UnQual ()) (sym ":<|>")) r)
+servantSub = foldr' (\l r -> TyInfix () l ((UnpromotedName () . UnQual ()) (sym ":>")) r)
 
-jsonVerb :: Method a -> Type
+jsonVerb :: Method a -> Type ()
 jsonVerb m =
-    TyApp (TyApp (httpMethod m) jsonMedia)
-        $ maybe (TyCon "()") (tycon . ref) (_mResponse m)
+    TyApp () (TyApp () (httpMethod m) jsonMedia)
+        $ maybe (TyCon () "()") (tycon . ref) (_mResponse m)
 
-downloadVerb :: Method a -> Type
+downloadVerb :: Method a -> Type ()
 downloadVerb m =
-    TyApp (TyApp (httpMethod m) streamMedia)
-          (TyCon "Stream")
+    TyApp () (TyApp () (httpMethod m) streamMedia)
+          (TyCon () "Stream")
 
-httpMethod :: Method a -> Type
-httpMethod = TyCon . unqual . Text.unpack . Text.toTitle . _mHttpMethod
+httpMethod :: Method a -> Type ()
+httpMethod = TyCon () . unqual . Text.unpack . Text.toTitle . _mHttpMethod
 
-subPaths :: Text -> [Type]
+subPaths :: Text -> [Type ()]
 subPaths = map sing . filter (not . Text.null) . Text.split (== '/')
 
-jsonMedia, streamMedia :: Type
+jsonMedia, streamMedia :: Type ()
 jsonMedia   = tylist ["JSON"]
 streamMedia = tylist ["OctetStream"]
 
-downloadParam :: Type
+downloadParam :: Type ()
 downloadParam =
-    TyApp (TyApp (TyCon "QueryParam") (sing "alt"))
-          (TyCon "AltMedia")
+    TyApp () (TyApp () (TyCon () "QueryParam") (sing "alt"))
+          (TyCon () "AltMedia")
 
-mediaParam :: Type
+mediaParam :: Type ()
 mediaParam =
-    TyApp (TyApp (TyCon "QueryParam") (sing "uploadType"))
-          (TyCon "AltMedia")
+    TyApp () (TyApp () (TyCon () "QueryParam") (sing "uploadType"))
+          (TyCon () "AltMedia")
 
-multipartParam :: Type
+multipartParam :: Type ()
 multipartParam =
-    TyApp (TyApp (TyCon "QueryParam") (sing "uploadType"))
-          (TyCon "Multipart")
+    TyApp () (TyApp () (TyCon () "QueryParam") (sing "uploadType"))
+          (TyCon () "Multipart")
 
-metadataPat, downloadPat, uploadPat :: Method a -> Pat
-metadataPat = pattern 1
-downloadPat = pattern 2
-uploadPat   = pattern 3
-
-pattern :: Integer -> Method a -> Pat
-pattern n m = case (n, down, up) of
+pattern' :: Integer -> Method a -> Pat ()
+pattern' n m = case (n, down, up) of
     (1, True, True) -> infixOr go   (infixOr wild wild)
     (2, True, True) -> infixOr wild (infixOr go   wild)
     (_, True, True) -> infixOr wild (infixOr wild go)
@@ -214,51 +208,57 @@ pattern n m = case (n, down, up) of
     up   = _mSupportsMediaUpload   m
 
     go   = pvar "go"
-    wild = PWildCard
+    wild = PWildCard ()
 
-    infixOr l r = PInfixApp l (UnQual (sym ":<|>")) r
+    infixOr l = PInfixApp () l (UnQual () (sym ":<|>"))
+
+metadataPat, downloadPat, uploadPat :: Method a -> Pat ()
+metadataPat = pattern' 1
+downloadPat = pattern' 2
+uploadPat   = pattern' 3
+
 
 downloadDecl :: Global
              -> Prefix
-             -> Name
-             -> Name
+             -> Name ()
+             -> Name ()
              -> [Local]
              -> Method Solved
-             -> Decl
+             -> Decl ()
 downloadDecl n pre api url fs m =
-    googleRequestDecl ty [rs, ss] [alt] pre api url m pat prec
+    googleRequestDecl (TyParen () ty) [rs, ss] [alt] pre api url m pat prec
   where
-    ty = TyApp (TyCon "MediaDownload") (tycon n)
+    ty = TyApp () (TyCon () "MediaDownload") (tycon n)
 
-    rs = InsType noLoc (TyApp (TyCon "Rs") ty) (TyCon "Stream")
+    rs = InsType () (TyApp () (TyCon () "Rs") ty) (TyCon () "Stream")
 
-    ss = InsType noLoc (TyApp (TyCon "Scopes") ty) $
-        TyApp (TyCon "Scopes") (tycon n)
+    ss = InsType () (TyApp () (TyCon () "Scopes") ty) $
+        TyApp () (TyCon () "Scopes") (tycon n)
 
     alt = app (var "Just") (var "AltMedia")
     pat = downloadPat m
 
-    prec = PApp (UnQual "MediaDownload")
-        [ PRec (UnQual (dname' n)) [PFieldWildcard | not (null fs)]
+    prec = PApp () (UnQual () "MediaDownload")
+        [ PRec () (UnQual () (dname' n)) [PFieldWildcard () | not (null fs)]
         ]
 
 uploadDecl :: Global
              -> Prefix
-             -> Name
-             -> Name
+             -> Name ()
+             -> Name ()
              -> [Local]
              -> Method Solved
-             -> Decl
+             -> Decl ()
 uploadDecl n pre api url fs m =
-    googleRequestDecl ty [rs, ss] extras pre api url m pat prec
+    googleRequestDecl (TyParen () ty) [rs, ss] extras pre api url m pat prec
   where
-    ty = TyApp (TyCon "MediaUpload") (tycon n)
+    ty = TyApp () (TyCon () "MediaUpload") (tycon n)
 
-    rs = InsType noLoc (TyApp (TyCon "Rs") ty) $
-        maybe unit_tycon (tycon . ref) (_mResponse m)
+    rs = InsType () (TyApp () (TyCon () "Rs") ty) $
+        maybe (unit_tycon ()) (tycon . ref) (_mResponse m)
 
-    ss = InsType noLoc (TyApp (TyCon "Scopes") ty) $
-        TyApp (TyCon "Scopes") (tycon n)
+    ss = InsType () (TyApp () (TyCon () "Scopes") ty) $
+         TyApp () (TyCon () "Scopes") (tycon n)
 
     extras = maybeToList alt ++ [upl] ++ payload ++ [var media]
       where
@@ -276,30 +276,32 @@ uploadDecl n pre api url fs m =
 
     pat = uploadPat m
 
-    prec = PApp (UnQual "MediaUpload")
-        [ PRec (UnQual (dname' n)) [PFieldWildcard | not (null fs)]
-        , PVar media
+    prec = PApp () (UnQual () "MediaUpload")
+        [ PRec () (UnQual () (dname' n)) [PFieldWildcard () | not (null fs)]
+        , PVar () media
         ]
 
     media = name "body"
 
 requestDecl :: Global
             -> Prefix
-            -> Name
-            -> Name
+            -> Name ()
+            -> Name ()
             -> [Local]
             -> Method Solved
-            -> Decl
+            -> Decl ()
 requestDecl n pre api url fs m =
     googleRequestDecl (tycon n) [rs, ss] extras pre api url m pat prec
   where
-    rs = InsType noLoc (TyApp (TyCon "Rs") (tycon n)) $
-        maybe unit_tycon (tycon . ref) (_mResponse m)
+    rs :: InstDecl ()
+    rs = InsType () (TyApp () (TyCon () "Rs") (tycon n)) $
+        maybe (unit_tycon ()) (tycon . ref) (_mResponse m)
 
-    ss = InsType noLoc (TyApp (TyCon "Scopes") (tycon n)) $
-        TyPromoted $
-            PromotedList True $
-                map (TyPromoted . PromotedString . Text.unpack) (_mScopes m)
+    ss :: InstDecl ()
+    ss = InsType () (TyApp () (TyCon () "Scopes") (tycon n)) $
+        TyPromoted () $
+            PromotedList () True $
+                map (\m' -> TyPromoted () (PromotedString () (Text.unpack m') "Scopes")) (_mScopes m)
 
     extras = catMaybes [alt, payload]
       where
@@ -312,35 +314,35 @@ requestDecl n pre api url fs m =
 
     pat = metadataPat m
 
-    prec = PRec (UnQual (dname' n)) [PFieldWildcard | not (null fs)]
+    prec = PRec () (UnQual () (dname' n)) [PFieldWildcard () | not (null fs)]
 
-googleRequestDecl :: Type
-                  -> [InstDecl]
-                  -> [Exp]
+googleRequestDecl :: Type ()
+                  -> [InstDecl ()]
+                  -> [Exp ()]
                   -> Prefix
-                  -> Name
-                  -> Name
+                  -> Name ()
+                  -> Name ()
                   -> Method Solved
-                  -> Pat
-                  -> Pat
-                  -> Decl
+                  -> Pat ()
+                  -> Pat ()
+                  -> Decl ()
 googleRequestDecl n assoc extras pre api url m pat prec =
-    InstDecl noLoc Nothing [] [] (unqual "GoogleRequest") [n] (assoc ++ [request])
+    InstDecl () Nothing (instrule "GoogleRequest" n) (Just (assoc ++ [request]))
   where
-    request = InsDecl (FunBind [match])
+    request = InsDecl () (FunBind () [match])
 
-    match = Match noLoc (name "requestClient") [prec] Nothing rhs (Just decls)
+    match = Match () (name "requestClient") [prec] rhs (Just decls)
 
-    decls = BDecls
-        [ patBind noLoc pat $
+    decls = BDecls ()
+        [ patBind pat $
             appFun (var "buildClient") $
-                [ ExpTypeSig noLoc (var "Proxy") $
-                    TyApp (TyCon "Proxy") (TyCon (UnQual api))
+                [ ExpTypeSig () (var "Proxy") $
+                    TyApp () (TyCon () "Proxy") (TyCon () (UnQual () api))
                 , var "mempty"
                 ]
         ]
 
-    rhs = UnGuardedRhs . appFun (var "go") $ map go fs ++ extras ++ [var url]
+    rhs = UnGuardedRhs () . appFun (var "go") $ map go fs ++ extras ++ [var url]
       where
         go l = case Map.lookup l ps of
             Just p | _pLocation p == Query
@@ -365,16 +367,15 @@ googleRequestDecl n assoc extras pre api url m pat prec =
        . nub
        $ map fst (rights (extractPath (_mPath m))) ++ _mParameterOrder m
 
-jsonDecls :: Global -> Prefix -> Map Local Solved -> [Decl]
+jsonDecls :: Global -> Prefix -> Map Local Solved -> [Decl ()]
 jsonDecls g p (Map.toList -> rs) = [from', to']
   where
-    from' = InstDecl noLoc Nothing [] [] (unqual "FromJSON") [tycon g]
+    from' = InstDecl () Nothing (instrule "FromJSON" (tycon g)) (Just
         [ funD "parseJSON" $
             app (app (var "withObject") (dstr g)) $
-                lamE noLoc [pvar "o"] $
+                lamE [pvar "o"] $
                     ctorE g (map decode rs)
-        ]
-
+        ])
     decode (l, s)
         | _additional s   = app (var "parseJSONObject") (var "o")
         | Just x <- def s = defJS l x
@@ -384,15 +385,15 @@ jsonDecls g p (Map.toList -> rs) = [from', to']
 
     to' = case rs of
         [(k, v)] | _additional v ->
-            InstDecl noLoc Nothing [] [] (unqual "ToJSON") [tycon g]
+            InstDecl () Nothing (instrule "ToJSON" (tycon g)) (Just
                 [ funD "toJSON" $
                     infixApp (var "toJSON") "." (var (fname p k))
-                ]
+                ])
 
         _                   ->
-            InstDecl noLoc Nothing [] [] (unqual "ToJSON") [tycon g]
+            InstDecl () Nothing (instrule "ToJSON" (tycon g)) (Just
                 [ wildcardD "toJSON" g omit emptyObj (map encode rs)
-                ]
+                ])
 
     omit = app (var "object")
          . app (var "catMaybes")
@@ -410,81 +411,99 @@ jsonDecls g p (Map.toList -> rs) = [from', to']
 
 wildcardD :: String
           -> Global
-          -> ([Exp] -> Exp)
-          -> Exp
-          -> [Exp]
-          -> InstDecl
+          -> ([Exp ()] -> Exp ())
+          -> Exp ()
+          -> [Exp ()]
+          -> InstDecl ()
 wildcardD f n enc x = \case
     [] -> constD f x
-    xs -> InsDecl (FunBind [match prec xs])
+    xs -> InsDecl () (FunBind () [match prec xs])
   where
     match p es =
-        Match noLoc (name f) [p] Nothing (UnGuardedRhs (enc es)) noBinds
+        Match () (name f) [p] (UnGuardedRhs () (enc es)) noBinds
 
-    prec = PRec (UnQual (dname' n)) [PFieldWildcard]
+    prec = PRec () (UnQual () (dname' n)) [PFieldWildcard ()]
 
-defJS :: Local -> Exp -> Exp
+defJS :: Local -> Exp () -> Exp ()
 defJS n x = infixApp (infixApp (var "o") ".:?" (fstr n)) ".!=" x
 
-reqJS :: Local -> Exp
+reqJS :: Local -> Exp ()
 reqJS = infixApp (var "o") ".:" . fstr
 
-optJS :: Local -> Exp
+optJS :: Local -> Exp ()
 optJS = infixApp (var "o") ".:?" . fstr
 
-funD :: String -> Exp -> InstDecl
-funD f = InsDecl . patBind noLoc (pvar (name f))
+funD :: String -> Exp () -> InstDecl ()
+funD f = InsDecl () . patBind (pvar (name f))
 
-constD :: String -> Exp -> InstDecl
-constD f x = InsDecl $
-    sfun noLoc (name f) [] (UnGuardedRhs (app (var "const") x)) noBinds
+constD :: String -> Exp () -> InstDecl ()
+constD f x = InsDecl () $
+    sfun (name f) [] (UnGuardedRhs () (app (var "const") x)) noBinds
 
-ctorE :: Global -> [Exp] -> Exp
+ctorE :: Global -> [Exp ()] -> Exp ()
 ctorE n = seqE (var (dname' n)) . map paren
 
-seqE :: Exp -> [Exp] -> Exp
+seqE :: Exp () -> [Exp ()] -> Exp ()
 seqE l []     = app (var "pure") l
 seqE l (r:rs) = infixApp l "<$>" (infixE r "<*>" rs)
 
-objDecl :: Global -> Prefix -> [Derive] -> Map Local Solved -> Decl
+objDecl :: Global -> Prefix -> [Derive] -> Map Local Solved -> Decl ()
 objDecl n p ds rs =
-    DataDecl noLoc arity [] (dname n) [] [conDecl (dname' n) p rs] (der ds)
+    DataDecl () arity Nothing (DHead () (dname n)) [conDecl (dname' n) p rs] [(der ds)]
   where
-    arity | Map.size rs == 1 = NewType
-          | otherwise        = DataType
+    arity | Map.size rs == 1 = NewType ()
+          | otherwise        = DataType ()
 
-    der = map ((,[]) . unqual . drop 1 . show)
+    der = Deriving () Nothing . map (unqualrule . drop 1 . show)
 
-conDecl :: Name -> Prefix -> Map Local Solved -> QualConDecl
-conDecl n p rs = QualConDecl noLoc [] [] body
+-- decl =
+--   DataDecl
+--     ()
+--     (DataType ())
+--     Nothing
+--     (DHead () (Ident () "AboutGet"))
+--     [QualConDecl () Nothing Nothing (ConDecl () (Ident () "AboutGet'") [])]
+--     [ Deriving
+--         ()
+--         Nothing
+--         [ IRule () Nothing Nothing (IHCon () (UnQual () (Ident () "Eq")))
+--         , IRule () Nothing Nothing (IHCon () (UnQual () (Ident () "Show")))
+--         , IRule () Nothing Nothing (IHCon () (UnQual () (Ident () "Data")))
+--         , IRule () Nothing Nothing (IHCon () (UnQual () (Ident () "Typeable")))
+--         , IRule () Nothing Nothing (IHCon () (UnQual () (Ident () "Generic")))
+--         ]
+--     ]
+
+conDecl :: Name () -> Prefix -> Map Local Solved -> QualConDecl ()
+conDecl n p rs = QualConDecl () Nothing Nothing body
   where
     body = case Map.toList rs of
-        []  -> ConDecl n []
-        [x] -> RecDecl n [field internalType x]
-        xs  -> RecDecl n (map (field (strict . internalType)) xs)
+        []  -> ConDecl () n []
+        [x] -> RecDecl () n [field internalType x]
+        xs  -> RecDecl () n (map (field (strict . internalType)) xs)
 
-    field f (l, v) = ([fname p l], f (_type v))
+    field f (l, v) = FieldDecl () [fname p l] (f (_type v))
 
-ctorSig :: Global -> Map Local Solved -> Decl
-ctorSig n rs = TypeSig noLoc [cname n] ts
+ctorSig :: Global -> Map Local Solved -> Decl ()
+ctorSig n rs = TypeSig () [cname n] ts
   where
-    ts = foldr' TyFun (TyCon (UnQual (dname n))) ps
+    ts = foldr' (TyFun ()) (TyCon () (UnQual () (dname n))) ps
     ps = parameters (Map.elems rs)
 
-ctorDecl :: Global -> Prefix -> Map Local Solved -> Decl
-ctorDecl n p rs = sfun noLoc c ps (UnGuardedRhs rhs) noBinds
+ctorDecl :: Global -> Prefix -> Map Local Solved -> Decl ()
+ctorDecl n p rs = sfun c ps (UnGuardedRhs () rhs) noBinds
   where
     c = cname  n
     d = dname' n
 
     rhs | Map.null rs = var d
-        | otherwise   = RecConstr (UnQual d) $
+        | otherwise   = RecConstr () (UnQual () d) $
             map (uncurry (fieldUpdate p)) (Map.toList rs)
 
     ps = map (pname p) . Map.keys $ Map.filter parameter rs
 
-fieldUpdate :: Prefix -> Local -> Solved -> FieldUpdate
-fieldUpdate p l s = FieldUpdate (UnQual (fname p l)) rhs
+fieldUpdate :: Prefix -> Local -> Solved -> FieldUpdate ()
+fieldUpdate p l s = FieldUpdate () (UnQual () (fname p l)) rhs
   where
     rhs | Just x <- def s, s ^. iRepeated = listE [x]
         | Just x <- def s                 = x
@@ -494,26 +513,26 @@ fieldUpdate p l s = FieldUpdate (UnQual (fname p l)) rhs
 
     v = var (pname p l)
 
-lensSig :: Global -> Prefix -> Local -> Solved -> Decl
-lensSig n p l s = TypeSig noLoc [lname p l] $
-    TyApp (TyApp (TyCon "Lens'") (tycon n))
+lensSig :: Global -> Prefix -> Local -> Solved -> Decl ()
+lensSig n p l s = TypeSig () [lname p l] $
+    TyApp () (TyApp () (TyCon () "Lens'") (tycon n))
           (externalType (_type s))
 
-lensDecl :: Prefix -> Local -> Solved -> Decl
-lensDecl p l s = sfun noLoc (lname p l) [] (UnGuardedRhs rhs) noBinds
+lensDecl :: Prefix -> Local -> Solved -> Decl ()
+lensDecl p l s = sfun (lname p l) [] (UnGuardedRhs () rhs) noBinds
   where
     f = fname p l
     t = _type s
 
     rhs = mapping t $
         app (app (var "lens") (var f))
-            (paren (lamE noLoc [pvar "s", pvar "a"]
-                   (RecUpdate (var "s") [FieldUpdate (UnQual f) (var "a")])))
+            (paren (lamE [pvar "s", pvar "a"]
+                   (RecUpdate () (var "s") [FieldUpdate () (UnQual () f) (var "a")])))
 
-parameters :: [Solved] -> [Type]
+parameters :: [Solved] -> [Type ()]
 parameters = map (externalType . _type) . filter parameter
 
-def :: Solved -> Maybe Exp
+def :: Solved -> Maybe (Exp ())
 def s
     | Just x <- s ^. iDefault = Just (go x (_prefix s) (_schema s))
     | otherwise               = Nothing
@@ -527,77 +546,77 @@ def s
 
     lit = var . name . Text.unpack
 
-terminalType :: TType -> Type
+terminalType :: TType -> Type ()
 terminalType = internalType . go
   where
     go (TMaybe x) = go x
     go (TList  x) = go x
     go x          = x
 
-externalType :: TType -> Type
+externalType :: TType -> Type ()
 externalType = \case
     TType   r          -> tycon r
     TMaybe  t@TList {} -> externalType t
-    TMaybe  t          -> TyApp (TyCon "Maybe") (externalType t)
-    TList   t          -> TyList (externalType t)
+    TMaybe  t          -> TyApp () (TyCon () "Maybe") (externalType t)
+    TList   t          -> TyList () (externalType t)
     TLit    l          -> externalLit l
     TMap  k v          ->
-        TyApp (TyApp (TyCon "HashMap") (externalType k)) (externalType (require v))
+        TyApp () (TyApp () (TyCon () "HashMap") (externalType k)) (externalType (require v))
 
-internalType :: TType -> Type
+internalType :: TType -> Type ()
 internalType = \case
     TType   r -> tycon r
-    TMaybe  t -> TyApp (TyCon "Maybe") (internalType t)
-    TList   t -> TyList (internalType t)
+    TMaybe  t -> TyApp () (TyCon () "Maybe") (internalType t)
+    TList   t -> TyList () (internalType t)
     TLit    l -> internalLit l
     TMap  k v ->
-        TyApp (TyApp (TyCon "HashMap") (internalType k)) (internalType (require v))
+        TyApp () (TyApp () (TyCon () "HashMap") (internalType k)) (internalType (require v))
 
-externalLit :: Lit -> Type
+externalLit :: Lit -> Type ()
 externalLit = \case
-    Text       -> TyCon "Text"
-    Bool       -> TyCon "Bool"
-    Time       -> TyCon "TimeOfDay"
-    Date       -> TyCon "Day"
-    DateTime   -> TyCon "UTCTime"
-    Nat        -> TyCon "Natural"
-    Float      -> TyCon "Double"
-    Double     -> TyCon "Double"
-    Byte       -> TyCon "ByteString"
-    UInt32     -> TyCon "Word32"
-    UInt64     -> TyCon "Word64"
-    Int32      -> TyCon "Int32"
-    Int64      -> TyCon "Int64"
-    Alt t      -> TyCon (unqual (Text.unpack t))
-    RqBody     -> TyCon "RequestBody"
-    RsBody     -> TyCon "Stream"
-    JSONValue  -> TyCon "JSONValue"
-    GFieldMask -> TyCon "GFieldMask"
-    GDuration  -> TyCon "Scientific"
+    Text       -> TyCon () "Text"
+    Bool       -> TyCon () "Bool"
+    Time       -> TyCon () "TimeOfDay"
+    Date       -> TyCon () "Day"
+    DateTime   -> TyCon () "UTCTime"
+    Nat        -> TyCon () "Natural"
+    Float      -> TyCon () "Double"
+    Double     -> TyCon () "Double"
+    Byte       -> TyCon () "ByteString"
+    UInt32     -> TyCon () "Word32"
+    UInt64     -> TyCon () "Word64"
+    Int32      -> TyCon () "Int32"
+    Int64      -> TyCon () "Int64"
+    Alt t      -> TyCon () (unqual (Text.unpack t))
+    RqBody     -> TyCon () "RequestBody"
+    RsBody     -> TyCon () "Stream"
+    JSONValue  -> TyCon () "JSONValue"
+    GFieldMask -> TyCon () "GFieldMask"
+    GDuration  -> TyCon () "Scientific"
 
-internalLit :: Lit -> Type
+internalLit :: Lit -> Type ()
 internalLit = \case
-    Text       -> TyCon "Text"
-    Bool       -> TyCon "Bool"
-    Time       -> TyCon "Time'"
-    Date       -> TyCon "Date'"
-    DateTime   -> TyCon "DateTime'"
-    Nat        -> TyApp (TyCon "Textual") (TyCon "Nat")
-    Float      -> TyApp (TyCon "Textual") (TyCon "Double")
-    Double     -> TyApp (TyCon "Textual") (TyCon "Double")
-    Byte       -> TyCon "Bytes"
-    UInt32     -> TyApp (TyCon "Textual") (TyCon "Word32")
-    UInt64     -> TyApp (TyCon "Textual") (TyCon "Word64")
-    Int32      -> TyApp (TyCon "Textual") (TyCon "Int32")
-    Int64      -> TyApp (TyCon "Textual") (TyCon "Int64")
-    Alt t      -> TyCon (unqual (Text.unpack t))
-    RqBody     -> TyCon "RequestBody"
-    RsBody     -> TyCon "Stream"
-    JSONValue  -> TyCon "JSONValue"
-    GFieldMask -> TyCon "GFieldMask"
-    GDuration  -> TyCon "GDuration"
+    Text       -> TyCon () "Text"
+    Bool       -> TyCon () "Bool"
+    Time       -> TyCon () "Time'"
+    Date       -> TyCon () "Date'"
+    DateTime   -> TyCon () "DateTime'"
+    Nat        -> TyApp () (TyCon () "Textual") (TyCon () "Nat")
+    Float      -> TyApp () (TyCon () "Textual") (TyCon () "Double")
+    Double     -> TyApp () (TyCon () "Textual") (TyCon () "Double")
+    Byte       -> TyCon () "Bytes"
+    UInt32     -> TyApp () (TyCon () "Textual") (TyCon () "Word32")
+    UInt64     -> TyApp () (TyCon () "Textual") (TyCon () "Word64")
+    Int32      -> TyApp () (TyCon () "Textual") (TyCon () "Int32")
+    Int64      -> TyApp () (TyCon () "Textual") (TyCon () "Int64")
+    Alt t      -> TyCon () (unqual (Text.unpack t))
+    RqBody     -> TyCon () "RequestBody"
+    RsBody     -> TyCon () "Stream"
+    JSONValue  -> TyCon () "JSONValue"
+    GFieldMask -> TyCon () "GFieldMask"
+    GDuration  -> TyCon () "GDuration"
 
-mapping :: TType -> Exp -> Exp
+mapping :: TType -> Exp () -> Exp ()
 mapping t e = infixE e "." (go t)
   where
     go = \case
@@ -608,7 +627,7 @@ mapping t e = infixE e "." (go t)
     nest []     = []
     nest (x:xs) = [app (var "mapping") (infixE x "." xs)]
 
-iso :: TType -> Maybe Exp
+iso :: TType -> Maybe (Exp ())
 iso = \case
     TList {}       -> Just (var "_Coerce")
     TMap  {}       -> Just (var "_Coerce")
@@ -630,27 +649,33 @@ require :: TType -> TType
 require (TMaybe t) = t
 require t          = t
 
-strict :: Type -> Type
-strict = TyBang BangedTy . \case
-    t@TyApp{} -> TyParen t
+strict :: Type () -> Type ()
+strict = TyBang () (BangedTy ()) (NoUnpackPragma ()) . \case
+    t@TyApp{} -> TyParen () t
     t         -> t
 
-sing :: Text -> Type
-sing = TyCon . unqual . Text.unpack . flip mappend "\"" . mappend "\""
+sing :: Text -> Type ()
+sing = TyCon () . unqual . Text.unpack . flip mappend "\"" . mappend "\""
 
-tylist :: [Text] -> Type
-tylist xs = TyCon . UnQual . name . Text.unpack $
+tylist :: [Text] -> Type ()
+tylist xs = TyCon () . UnQual () . name . Text.unpack $
     "'[" <> Text.intercalate ", " xs <> "]"
 
-tycon :: Global -> Type
-tycon = TyCon . UnQual . dname
+tycon :: Global -> Type ()
+tycon = TyCon () . UnQual () . dname
 
-unqual :: String -> QName
-unqual = UnQual . name
+unqual :: String -> QName ()
+unqual = UnQual () . name
 
-infixE :: Exp -> QOp -> [Exp] -> Exp
+unqualrule  :: String -> InstRule ()
+unqualrule = IRule () Nothing Nothing . IHCon () . unqual
+
+instrule :: String -> Type () -> InstRule ()
+instrule n t = IRule () Nothing Nothing (IHApp () (IHCon () (unqual n)) t)
+
+infixE :: Exp () -> QOp () -> [Exp ()] -> Exp ()
 infixE l _ []     = l
 infixE l o (r:rs) = infixE (infixApp l o r) o rs
 
-str :: Text -> Exp
+str :: Text -> Exp ()
 str = strE . Text.unpack

--- a/gen/src/Gen/Text.hs
+++ b/gen/src/Gen/Text.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TupleSections     #-}
 
 -- Module      : Gen.Text
 -- Copyright   : (c) 2013-2015 Brendan Hay

--- a/gen/src/Gen/Text.hs
+++ b/gen/src/Gen/Text.hs
@@ -19,7 +19,6 @@ import           Data.Char
 import qualified Data.Foldable         as Fold
 import qualified Data.HashMap.Strict   as Map
 import qualified Data.HashSet          as Set
-import           Data.Monoid
 import           Data.String
 import           Data.Text             (Text)
 import qualified Data.Text             as Text

--- a/gen/src/Gen/Tree.hs
+++ b/gen/src/Gen/Tree.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE RecordWildCards       #-}
-{-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE ViewPatterns          #-}
 
 -- Module      : Gen.Tree

--- a/gen/src/Gen/Types/Data.hs
+++ b/gen/src/Gen/Types/Data.hs
@@ -47,7 +47,7 @@ data Syn a = Syn { syntax :: a }
 instance Pretty a => ToJSON (Syn a) where
     toJSON = toJSON . prettyPrint . syntax
 
-data Fun = Fun' Name (Maybe Help) Rendered Rendered
+data Fun = Fun' (Name ()) (Maybe Help) Rendered Rendered
 
 instance ToJSON Fun where
     toJSON (Fun' n h s d) = object
@@ -57,7 +57,7 @@ instance ToJSON Fun where
         , "decl" .= d
         ]
 
-data Branch = Branch Name Text Help
+data Branch = Branch (Name ()) Text Help
 
 instance ToJSON Branch where
     toJSON (Branch n v h) = object
@@ -67,8 +67,8 @@ instance ToJSON Branch where
         ]
 
 data Data
-    = Sum  Name (Maybe Help) [Branch]
-    | Prod Name (Maybe Help) Rendered Fun [Fun] [Rendered]
+    = Sum  (Name ()) (Maybe Help) [Branch]
+    | Prod (Name ()) (Maybe Help) Rendered Fun [Fun] [Rendered]
 
 instance ToJSON Data where
     toJSON = \case
@@ -89,7 +89,7 @@ instance ToJSON Data where
             , "instances" .= is
             ]
 
-dataName :: Data -> Name
+dataName :: Data -> Name ()
 dataName = \case
     Sum  n _ _       -> n
     Prod n _ _ _ _ _ -> n
@@ -99,7 +99,7 @@ data Action = Action
     , _actType      :: Global
     , _actNamespace :: NS
     , _actHelp      :: Maybe Help
-    , _actAliasName :: Name
+    , _actAliasName :: Name ()
     , _actAlias     :: Rendered
     , _actData      :: Data
     }
@@ -115,7 +115,7 @@ instance ToJSON Action where
         ]
 
 data API = API
-    { _apiAliasName :: Name
+    { _apiAliasName :: Name ()
     , _apiAlias     :: Rendered
     , _apiResources :: [Action]
     , _apiMethods   :: [Action]

--- a/gen/src/Gen/Types/Data.hs
+++ b/gen/src/Gen/Types/Data.hs
@@ -1,17 +1,10 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DeriveFoldable             #-}
-{-# LANGUAGE DeriveFunctor              #-}
-{-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DeriveTraversable          #-}
-{-# LANGUAGE ExtendedDefaultRules       #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE KindSignatures             #-}
-{-# LANGUAGE LambdaCase                 #-}
-{-# LANGUAGE OverloadedStrings          #-}
-{-# LANGUAGE RecordWildCards            #-}
-{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
+{-# LANGUAGE FlexibleContexts     #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE RecordWildCards      #-}
 
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
@@ -42,7 +35,7 @@ default (Text)
 
 type Rendered = LText.Text
 
-data Syn a = Syn { syntax :: a }
+newtype Syn a = Syn { syntax :: a }
 
 instance Pretty a => ToJSON (Syn a) where
     toJSON = toJSON . prettyPrint . syntax

--- a/gen/src/Gen/Types/Help.hs
+++ b/gen/src/Gen/Types/Help.hs
@@ -15,16 +15,16 @@ module Gen.Types.Help
     , rawHelpText
     ) where
 
-import Data.Aeson
-import Data.Char   (isSpace)
-import Data.String
-import Data.Text   (Text)
-import qualified System.IO.Unsafe as Unsafe
+import           Data.Aeson
+import           Data.Char          (isSpace)
+import           Data.String
+import           Data.Text          (Text)
+import qualified System.IO.Unsafe   as Unsafe
 
-import Text.Pandoc        as Pandoc
-import Text.Pandoc.Pretty
+import           Text.Pandoc        as Pandoc
+import           Text.Pandoc.Pretty
 
-import qualified Data.Text as Text
+import qualified Data.Text          as Text
 
 data Help
     = Help ![Help]

--- a/gen/src/Gen/Types/Id.hs
+++ b/gen/src/Gen/Types/Id.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE TupleSections              #-}
@@ -62,8 +61,7 @@ import qualified Data.CaseInsensitive         as CI
 import           Data.Foldable                (foldl')
 import           Data.Function                (on)
 import           Data.Hashable
-import           Data.List                    (intersperse)
-import           Data.List                    (elemIndex, nub, sortOn)
+import           Data.List                    (elemIndex, intersperse, nub, sortOn)
 import           Data.String
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text

--- a/gen/src/Gen/Types/NS.hs
+++ b/gen/src/Gen/Types/NS.hs
@@ -14,7 +14,6 @@ module Gen.Types.NS
     ) where
 
 import           Data.Aeson
-import           Data.Semigroup
 import           Data.String
 import           Data.Text            (Text)
 import qualified Data.Text            as Text

--- a/gen/src/Gen/Types/Schema.hs
+++ b/gen/src/Gen/Types/Schema.hs
@@ -425,7 +425,7 @@ data Service a = Service
     , _sOwnerName     :: Text
     , _sOwnerDomain   :: Text
     , _sPackagePath   :: Maybe Text
-    , _sDescription   :: (Description a)
+    , _sDescription   :: Description a
     } deriving (Eq, Show)
 
 makeClassy ''Service
@@ -448,8 +448,8 @@ serviceName = Text.unpack . (<> "Service") . toCamel . _sCanonicalName
 scopeName :: Service a -> Text -> String
 scopeName s k = Text.unpack . lowerHead . lowerFirstAcronym $
     case breakParts k of
-        []  -> _sCanonicalName s <> "AllScope"
-        xs  -> foldMap named xs <> "Scope"
+        [] -> _sCanonicalName s <> "AllScope"
+        xs -> foldMap named xs <> "Scope"
   where
     breakParts =
           concatMap (Text.split split)

--- a/gen/src/Gen/Types/Schema.hs
+++ b/gen/src/Gen/Types/Schema.hs
@@ -60,6 +60,9 @@ deriveJSON options ''Location
 newtype Ann = Ann { annRequired :: [Local] }
     deriving (Eq, Show, Monoid)
 
+instance Semigroup Ann where
+  a <> b = Ann (annRequired a <> annRequired b)
+
 deriveJSON options ''Ann
 
 data Info = Info

--- a/gen/stack.yaml
+++ b/gen/stack.yaml
@@ -1,11 +1,15 @@
-resolver: lts-8.18
+resolver: lts-13.7
 
 flags: {}
 
 extra-deps:
-  - text-regex-replace-0.1.1.1
-  - haskell-src-exts-1.17.1
-  - hindent-4.6.4
+  - text-regex-replace-0.1.1.3
+  - ede-0.2.9
+  - unexceptionalio-0.3.0
+  - github: chrisdone/hindent
+    size: 51114
+    commit: ad0c2a9f8755d37f09b356ab7e45a4e49bcda0b3
+    sha256: 19954fc7dff3d008d9c7688d1c571999c1869f86e5c115aef8b28c2ae622972f
 
 packages:
-  - '.'
+  - "."

--- a/stack-8.6.3.yaml
+++ b/stack-8.6.3.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.2
+resolver: lts-13.7
 
 local-bin-path: bin
 


### PR DESCRIPTION
*This is my first meddling with `haskell-src-exts`, so please take caution while reviewing this PR.*

What I did was mostly adding missing `()` which was introduced in data types from `haskell-src-exts` as  the annotation parameter `l`, which it seems is not necessary in our case.

This probably shouldn't be merged until `hindent` package has a new release since the latest version has a bug that causes a termination of the gogol-gen. That bug is fixed in the upstream, hence the additional `extra-deps` inside `gen/stack.yaml`.

I don't think the requirements above should prevent me from sending this PR, since they're all about upstream issues that are fixed but not yet released.

---

Regarding this upgrade, I took `gogol-drive` as my basis of comparison, so the resulting files are nearly identical except some changes in style caused by a change in [hindent since v5](https://chrisdone.com/posts/hindent-5):

### removed trailing `;`
``` diff
 -- | Modify your Google Apps Script scripts\' behavior
 driveScriptsScope :: Proxy '["https://www.googleapis.com/auth/drive.scripts"]
-driveScriptsScope = Proxy;
+driveScriptsScope = Proxy
```
### `deriving` and `FileList'` moved to a new line
``` diff
 -- | A list of files.
 --
 -- /See:/ 'fileList' smart constructor.
-data FileList = FileList'
+data FileList =
+  FileList'
     { _flNextPageToken    :: !(Maybe Text)
     , _flIncompleteSearch :: !(Maybe Bool)
     , _flKind             :: !Text
     , _flFiles            :: !(Maybe [File])
-    } deriving (Eq,Show,Data,Typeable,Generic)
+    }
+  deriving (Eq, Show, Data, Typeable, Generic)
+
```
### if a definition fits in a single line without breaking column limits, it is kept as so.
``` diff
 fileAppProperties pFapAddtional_ =
-    FileAppProperties'
-    { _fapAddtional = _Coerce # pFapAddtional_
-    }
+  FileAppProperties' {_fapAddtional = _Coerce # pFapAddtional_}
+
```

After making sure that generated package is identical to the one we generated before in v0.4.0, I went  ahead and tried compiling the result, which was successful. Then I've generated all of the gogol-* packages using the latest models from Google's repo, and they too were successfully compiled.

I have not added the resulting packages, since it causes a huge noise in the diff of the PR. So, if this PR gets merged successfully, I'll go ahead and prepare the gogol-* packages for the next release.

There is one caveat though, on the last version of models, there is a new model called `docs`, which this generator fails to create it's respecting `gogol-docs` library. It'll probably require a more detailed work, and I don't think  it'll also work for the older generator.

Since it's nearly impossible to check all of the diffs, I expect @brendanhay's input to look for edge cases.

note: I'm not very proud of using unsafe methods in `gen/src/Gen/Types/Help.hs` to prevent introducing monads to the source.