### PR TITLE
RunQueryResponse should be an array

### DIFF
--- a/gogol-firestore/gen/Network/Google/Resource/FireStore/Projects/Databases/Documents/RunQuery.hs
+++ b/gogol-firestore/gen/Network/Google/Resource/FireStore/Projects/Databases/Documents/RunQuery.hs
@@ -57,7 +57,7 @@ type ProjectsDatabasesDocumentsRunQueryResource =
                  QueryParam "callback" Text :>
                    QueryParam "alt" AltJSON :>
                      ReqBody '[JSON] RunQueryRequest :>
-                       Post '[JSON] RunQueryResponse
+                       Post '[JSON] [RunQueryResponse]
 
 -- | Runs a query.
 --
@@ -156,7 +156,7 @@ instance GoogleRequest
            ProjectsDatabasesDocumentsRunQuery
          where
         type Rs ProjectsDatabasesDocumentsRunQuery =
-             RunQueryResponse
+             [RunQueryResponse]
         type Scopes ProjectsDatabasesDocumentsRunQuery =
              '["https://www.googleapis.com/auth/cloud-platform",
                "https://www.googleapis.com/auth/datastore"]


### PR DESCRIPTION
Querying something on:
`https://firestore.googleapis.com/v1/projects/xxxxx/databases/(default)/documents:runQuery`

returns this:

`
[
    {
        "document": {
            "name": "projects/xxxxx/databases/(default)/documents/doc/000000000",
            "fields": {
                "lastUpdate": {
...         }
    }
]
`

Which is a list of `RunQueryResponse`s instead of the single one. I'm not sure if this patch is applied to the right place due the code generation but I couldn't figure out exactly where to do it. If someone can point me the correct direction, I'll update this PR.  