### PR TITLE
Update Cloud Tasks API to include the HTTPRequest in the task

### DIFF
--- a/gen/model/cloudtasks/v2/cloudtasks-api.json
+++ b/gen/model/cloudtasks/v2/cloudtasks-api.json
@@ -22,6 +22,7 @@
   },
   "id": "cloudtasks:v2",
   "kind": "discovery#restDescription",
+  "mtlsRootUrl": "https://cloudtasks.mtls.googleapis.com/",
   "name": "cloudtasks",
   "ownerDomain": "google.com",
   "ownerName": "Google",
@@ -188,7 +189,7 @@
                   ],
                   "parameters": {
                     "parent": {
-                      "description": "Required.\n\nThe location name in which the queue will be created.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`\n\nThe list of allowed locations can be obtained by calling Cloud\nTasks' implementation of\nListLocations.",
+                      "description": "Required. The location name in which the queue will be created.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`\n\nThe list of allowed locations can be obtained by calling Cloud\nTasks' implementation of\nListLocations.",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+$",
                       "required": true,
@@ -216,7 +217,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -241,7 +242,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe resource name of the queue. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The resource name of the queue. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -310,7 +311,7 @@
                       "type": "string"
                     },
                     "parent": {
-                      "description": "Required.\n\nThe location name.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`",
+                      "description": "Required. The location name.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+$",
                       "required": true,
@@ -369,7 +370,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -397,7 +398,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -425,7 +426,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -504,7 +505,7 @@
                 "tasks": {
                   "methods": {
                     "create": {
-                      "description": "Creates a task and adds it to a queue.\n\nTasks cannot be updated after creation; there is no UpdateTask command.\n\n* For App Engine queues, the maximum task size is\n  100KB.",
+                      "description": "Creates a task and adds it to a queue.\n\nTasks cannot be updated after creation; there is no UpdateTask command.\n\n* The maximum task size is 100KB.",
                       "flatPath": "v2/projects/{projectsId}/locations/{locationsId}/queues/{queuesId}/tasks",
                       "httpMethod": "POST",
                       "id": "cloudtasks.projects.locations.queues.tasks.create",
@@ -513,7 +514,7 @@
                       ],
                       "parameters": {
                         "parent": {
-                          "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`\n\nThe queue must already exist.",
+                          "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`\n\nThe queue must already exist.",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                           "required": true,
@@ -541,7 +542,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -566,7 +567,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -601,7 +602,7 @@
                       ],
                       "parameters": {
                         "pageSize": {
-                          "description": "Requested page size. Fewer tasks than requested might be returned.\n\nThe maximum page size is 1000. If unspecified, the page size will\nbe the maximum. Fewer tasks than requested might be returned,\neven if more tasks exist; use\nnext_page_token in the\nresponse to determine if more tasks exist.",
+                          "description": "Maximum page size.\n\nFewer tasks than requested might be returned, even if more tasks exist; use\nnext_page_token in the response to\ndetermine if more tasks exist.\n\nThe maximum page size is 1000. If unspecified, the page size will be the\nmaximum.",
                           "format": "int32",
                           "location": "query",
                           "type": "integer"
@@ -612,7 +613,7 @@
                           "type": "string"
                         },
                         "parent": {
-                          "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                          "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                           "required": true,
@@ -647,7 +648,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -674,16 +675,16 @@
       }
     }
   },
-  "revision": "20190412",
+  "revision": "20200529",
   "rootUrl": "https://cloudtasks.googleapis.com/",
   "schemas": {
     "AppEngineHttpRequest": {
-      "description": "App Engine HTTP request.\n\nThe message defines the HTTP request that is sent to an App Engine app when\nthe task is dispatched.\n\nThis proto can only be used for tasks in a queue which has\napp_engine_http_queue set.\n\nUsing AppEngineHttpRequest requires\n[`appengine.applications.get`](https://cloud.google.com/appengine/docs/admin-api/access-control)\nGoogle IAM permission for the project\nand the following scope:\n\n`https://www.googleapis.com/auth/cloud-platform`\n\nThe task will be delivered to the App Engine app which belongs to the same\nproject as the queue. For more information, see\n[How Requests are\nRouted](https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed)\nand how routing is affected by\n[dispatch\nfiles](https://cloud.google.com/appengine/docs/python/config/dispatchref).\nTraffic is encrypted during transport and never leaves Google datacenters.\nBecause this traffic is carried over a communication mechanism internal to\nGoogle, you cannot explicitly set the protocol (for example, HTTP or HTTPS).\nThe request to the handler, however, will appear to have used the HTTP\nprotocol.\n\nThe AppEngineRouting used to construct the URL that the task is\ndelivered to can be set at the queue-level or task-level:\n\n* If set,\n   app_engine_routing_override\n   is used for all tasks in the queue, no matter what the setting\n   is for the\n   task-level app_engine_routing.\n\n\nThe `url` that the task will be sent to is:\n\n* `url =` host `+`\n  relative_uri\n\nTasks can be dispatched to secure app handlers, unsecure app handlers, and\nURIs restricted with\n[`login:\nadmin`](https://cloud.google.com/appengine/docs/standard/python/config/appref).\nBecause tasks are not run as any user, they cannot be dispatched to URIs\nrestricted with\n[`login:\nrequired`](https://cloud.google.com/appengine/docs/standard/python/config/appref)\nTask dispatches also do not follow redirects.\n\nThe task attempt has succeeded if the app's request handler returns\nan HTTP response code in the range [`200` - `299`]. `503` is\nconsidered an App Engine system error instead of an application\nerror. Requests returning error `503` will be retried regardless of\nretry configuration and not counted against retry counts.\nAny other response code or a failure to receive a response before the\ndeadline is a failed attempt.",
+      "description": "App Engine HTTP request.\n\nThe message defines the HTTP request that is sent to an App Engine app when\nthe task is dispatched.\n\nUsing AppEngineHttpRequest requires\n[`appengine.applications.get`](https://cloud.google.com/appengine/docs/admin-api/access-control)\nGoogle IAM permission for the project\nand the following scope:\n\n`https://www.googleapis.com/auth/cloud-platform`\n\nThe task will be delivered to the App Engine app which belongs to the same\nproject as the queue. For more information, see\n[How Requests are\nRouted](https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed)\nand how routing is affected by\n[dispatch\nfiles](https://cloud.google.com/appengine/docs/python/config/dispatchref).\nTraffic is encrypted during transport and never leaves Google datacenters.\nBecause this traffic is carried over a communication mechanism internal to\nGoogle, you cannot explicitly set the protocol (for example, HTTP or HTTPS).\nThe request to the handler, however, will appear to have used the HTTP\nprotocol.\n\nThe AppEngineRouting used to construct the URL that the task is\ndelivered to can be set at the queue-level or task-level:\n\n* If app_engine_routing_override is set on the\n  queue, this value\n  is used for all tasks in the queue, no matter what the setting is for the\n  task-level\n  app_engine_routing.\n\n\nThe `url` that the task will be sent to is:\n\n* `url =` host `+`\n  relative_uri\n\nTasks can be dispatched to secure app handlers, unsecure app handlers, and\nURIs restricted with\n[`login:\nadmin`](https://cloud.google.com/appengine/docs/standard/python/config/appref).\nBecause tasks are not run as any user, they cannot be dispatched to URIs\nrestricted with\n[`login:\nrequired`](https://cloud.google.com/appengine/docs/standard/python/config/appref)\nTask dispatches also do not follow redirects.\n\nThe task attempt has succeeded if the app's request handler returns an HTTP\nresponse code in the range [`200` - `299`]. The task attempt has failed if\nthe app's handler returns a non-2xx response code or Cloud Tasks does\nnot receive response before the deadline. Failed\ntasks will be retried according to the\nretry configuration. `503` (Service Unavailable) is\nconsidered an App Engine system error instead of an application error and\nwill cause Cloud Tasks' traffic congestion control to temporarily throttle\nthe queue's dispatches. Unlike other types of task targets, a `429` (Too Many\nRequests) response from an app handler does not cause traffic congestion\ncontrol to throttle the queue.",
       "id": "AppEngineHttpRequest",
       "properties": {
         "appEngineRouting": {
           "$ref": "AppEngineRouting",
-          "description": "Task-level setting for App Engine routing.\n\nIf set,\napp_engine_routing_override\nis used for all tasks in the queue, no matter what the setting is for the\ntask-level app_engine_routing."
+          "description": "Task-level setting for App Engine routing.\n\n* If app_engine_routing_override is set on the\n  queue, this\n  value is used for all tasks in the queue, no matter what the setting is\n  for the task-level\n  app_engine_routing."
         },
         "body": {
           "description": "HTTP request body.\n\nA request body is allowed only if the HTTP method is POST or PUT. It is\nan error to set a body on a task with an incompatible HttpMethod.",
@@ -694,11 +695,11 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "HTTP request headers.\n\nThis map contains the header field names and values.\nHeaders can be set when the\ntask is created.\nRepeated headers are not supported but a header value can contain commas.\n\nCloud Tasks sets some headers to default values:\n\n* `User-Agent`: By default, this header is\n  `\"AppEngine-Google; (+http://code.google.com/appengine)\"`.\n  This header can be modified, but Cloud Tasks will append\n  `\"AppEngine-Google; (+http://code.google.com/appengine)\"` to the\n  modified `User-Agent`.\n\nIf the task has a body, Cloud\nTasks sets the following headers:\n\n* `Content-Type`: By default, the `Content-Type` header is set to\n  `\"application/octet-stream\"`. The default can be overridden by explicitly\n  setting `Content-Type` to a particular media type when the\n  task is created.\n  For example, `Content-Type` can be set to `\"application/json\"`.\n* `Content-Length`: This is computed by Cloud Tasks. This value is\n  output only.   It cannot be changed.\n\nThe headers below cannot be set or overridden:\n\n* `Host`\n* `X-Google-*`\n* `X-AppEngine-*`\n\nIn addition, Cloud Tasks sets some headers when the task is dispatched,\nsuch as headers containing information about the task; see\n[request\nheaders](https://cloud.google.com/appengine/docs/python/taskqueue/push/creating-handlers#reading_request_headers).\nThese headers are set only when the task is dispatched, so they are not\nvisible when the task is returned in a Cloud Tasks response.\n\nAlthough there is no specific limit for the maximum number of headers or\nthe size, there is a limit on the maximum size of the Task. For more\ninformation, see the CreateTask documentation.",
+          "description": "HTTP request headers.\n\nThis map contains the header field names and values.\nHeaders can be set when the\ntask is created.\nRepeated headers are not supported but a header value can contain commas.\n\nCloud Tasks sets some headers to default values:\n\n* `User-Agent`: By default, this header is\n  `\"AppEngine-Google; (+http://code.google.com/appengine)\"`.\n  This header can be modified, but Cloud Tasks will append\n  `\"AppEngine-Google; (+http://code.google.com/appengine)\"` to the\n  modified `User-Agent`.\n\nIf the task has a body, Cloud\nTasks sets the following headers:\n\n* `Content-Type`: By default, the `Content-Type` header is set to\n  `\"application/octet-stream\"`. The default can be overridden by explicitly\n  setting `Content-Type` to a particular media type when the\n  task is created.\n  For example, `Content-Type` can be set to `\"application/json\"`.\n* `Content-Length`: This is computed by Cloud Tasks. This value is\n  output only.   It cannot be changed.\n\nThe headers below cannot be set or overridden:\n\n* `Host`\n* `X-Google-*`\n* `X-AppEngine-*`\n\nIn addition, Cloud Tasks sets some headers when the task is dispatched,\nsuch as headers containing information about the task; see\n[request\nheaders](https://cloud.google.com/tasks/docs/creating-appengine-handlers#reading_request_headers).\nThese headers are set only when the task is dispatched, so they are not\nvisible when the task is returned in a Cloud Tasks response.\n\nAlthough there is no specific limit for the maximum number of headers or\nthe size, there is a limit on the maximum size of the Task. For more\ninformation, see the CreateTask documentation.",
           "type": "object"
         },
         "httpMethod": {
-          "description": "The HTTP method to use for the request. The default is POST.\n\nThe app's request handler for the task's target URL must be able to handle\nHTTP requests with this http_method, otherwise the task attempt will fail\nwith error code 405 (Method Not Allowed). See\n[Writing a push task request\nhandler](https://cloud.google.com/appengine/docs/java/taskqueue/push/creating-handlers#writing_a_push_task_request_handler)\nand the documentation for the request handlers in the language your app is\nwritten in e.g.\n[Python Request\nHandler](https://cloud.google.com/appengine/docs/python/tools/webapp/requesthandlerclass).",
+          "description": "The HTTP method to use for the request. The default is POST.\n\nThe app's request handler for the task's target URL must be able to handle\nHTTP requests with this http_method, otherwise the task attempt fails with\nerror code 405 (Method Not Allowed). See [Writing a push task request\nhandler](https://cloud.google.com/appengine/docs/java/taskqueue/push/creating-handlers#writing_a_push_task_request_handler)\nand the App Engine documentation for your runtime on [How Requests are\nHandled](https://cloud.google.com/appengine/docs/standard/python3/how-requests-are-handled).",
           "enum": [
             "HTTP_METHOD_UNSPECIFIED",
             "POST",
@@ -729,7 +730,7 @@
       "type": "object"
     },
     "AppEngineRouting": {
-      "description": "App Engine Routing.\n\nDefines routing characteristics specific to App Engine - service, version,\nand instance.\n\nFor more information about services, versions, and instances see\n[An Overview of App\nEngine](https://cloud.google.com/appengine/docs/python/an-overview-of-app-engine),\n[Microservices Architecture on Google App\nEngine](https://cloud.google.com/appengine/docs/python/microservices-on-app-engine),\n[App Engine Standard request\nrouting](https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed),\nand [App Engine Flex request\nrouting](https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-routed).",
+      "description": "App Engine Routing.\n\nDefines routing characteristics specific to App Engine - service, version,\nand instance.\n\nFor more information about services, versions, and instances see\n[An Overview of App\nEngine](https://cloud.google.com/appengine/docs/python/an-overview-of-app-engine),\n[Microservices Architecture on Google App\nEngine](https://cloud.google.com/appengine/docs/python/microservices-on-app-engine),\n[App Engine Standard request\nrouting](https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed),\nand [App Engine Flex request\nrouting](https://cloud.google.com/appengine/docs/flexible/python/how-requests-are-routed).\n\nUsing AppEngineRouting requires\n[`appengine.applications.get`](https://cloud.google.com/appengine/docs/admin-api/access-control)\nGoogle IAM permission for the project\nand the following scope:\n\n`https://www.googleapis.com/auth/cloud-platform`",
       "id": "AppEngineRouting",
       "properties": {
         "host": {
@@ -783,10 +784,10 @@
       "properties": {
         "condition": {
           "$ref": "Expr",
-          "description": "The condition that is associated with this binding.\nNOTE: An unsatisfied condition will not allow user access via current\nbinding. Different bindings, including their conditions, are examined\nindependently."
+          "description": "The condition that is associated with this binding.\n\nIf the condition evaluates to `true`, then this binding applies to the\ncurrent request.\n\nIf the condition evaluates to `false`, then this binding does not apply to\nthe current request. However, a different role binding might grant the same\nrole to one or more of the members in this binding.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM\ndocumentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
         },
         "members": {
-          "description": "Specifies the identities requesting access for a Cloud Platform resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@gmail.com` .\n\n\n* `serviceAccount:{emailid}`: An email address that represents a service\n   account. For example, `my-other-app@appspot.gserviceaccount.com`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n\n* `domain:{domain}`: The G Suite domain (primary) that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n",
+          "description": "Specifies the identities requesting access for a Cloud Platform resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@example.com` .\n\n\n* `serviceAccount:{emailid}`: An email address that represents a service\n   account. For example, `my-other-app@appspot.gserviceaccount.com`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n* `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique\n   identifier) representing a user that has been recently deleted. For\n   example, `alice@example.com?uid=123456789012345678901`. If the user is\n   recovered, this value reverts to `user:{emailid}` and the recovered user\n   retains the role in the binding.\n\n* `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus\n   unique identifier) representing a service account that has been recently\n   deleted. For example,\n   `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`.\n   If the service account is undeleted, this value reverts to\n   `serviceAccount:{emailid}` and the undeleted service account retains the\n   role in the binding.\n\n* `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique\n   identifier) representing a Google group that has been recently\n   deleted. For example, `admins@example.com?uid=123456789012345678901`. If\n   the group is recovered, this value reverts to `group:{emailid}` and the\n   recovered group retains the role in the binding.\n\n\n* `domain:{domain}`: The G Suite domain (primary) that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n",
           "items": {
             "type": "string"
           },
@@ -819,7 +820,7 @@
         },
         "task": {
           "$ref": "Task",
-          "description": "Required.\n\nThe task to add.\n\nTask names have the following format:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.\nThe user can optionally specify a task name. If a\nname is not specified then the system will generate a random\nunique task id, which will be set in the task returned in the\nresponse.\n\nIf schedule_time is not set or is in the\npast then Cloud Tasks will set it to the current time.\n\nTask De-duplication:\n\nExplicitly specifying a task ID enables task de-duplication.  If\na task's ID is identical to that of an existing task or a task\nthat was deleted or executed recently then the call will fail\nwith ALREADY_EXISTS.\nIf the task's queue was created using Cloud Tasks, then another task with\nthe same name can't be created for ~1hour after the original task was\ndeleted or executed. If the task's queue was created using queue.yaml or\nqueue.xml, then another task with the same name can't be created\nfor ~9days after the original task was deleted or executed.\n\nBecause there is an extra lookup cost to identify duplicate task\nnames, these CreateTask calls have significantly\nincreased latency. Using hashed strings for the task id or for\nthe prefix of the task id is recommended. Choosing task ids that\nare sequential or have sequential prefixes, for example using a\ntimestamp, causes an increase in latency and error rates in all\ntask commands. The infrastructure relies on an approximately\nuniform distribution of task ids to store and serve tasks\nefficiently."
+          "description": "Required. The task to add.\n\nTask names have the following format:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.\nThe user can optionally specify a task name. If a\nname is not specified then the system will generate a random\nunique task id, which will be set in the task returned in the\nresponse.\n\nIf schedule_time is not set or is in the\npast then Cloud Tasks will set it to the current time.\n\nTask De-duplication:\n\nExplicitly specifying a task ID enables task de-duplication.  If\na task's ID is identical to that of an existing task or a task\nthat was deleted or executed recently then the call will fail\nwith ALREADY_EXISTS.\nIf the task's queue was created using Cloud Tasks, then another task with\nthe same name can't be created for ~1hour after the original task was\ndeleted or executed. If the task's queue was created using queue.yaml or\nqueue.xml, then another task with the same name can't be created\nfor ~9days after the original task was deleted or executed.\n\nBecause there is an extra lookup cost to identify duplicate task\nnames, these CreateTask calls have significantly\nincreased latency. Using hashed strings for the task id or for\nthe prefix of the task id is recommended. Choosing task ids that\nare sequential or have sequential prefixes, for example using a\ntimestamp, causes an increase in latency and error rates in all\ntask commands. The infrastructure relies on an approximately\nuniform distribution of task ids to store and serve tasks\nefficiently."
         }
       },
       "type": "object"
@@ -831,23 +832,23 @@
       "type": "object"
     },
     "Expr": {
-      "description": "Represents an expression text. Example:\n\n    title: \"User account presence\"\n    description: \"Determines whether the request has a user account\"\n    expression: \"size(request.user) \u003e 0\"",
+      "description": "Represents a textual expression in the Common Expression Language (CEL)\nsyntax. CEL is a C-like expression language. The syntax and semantics of CEL\nare documented at https://github.com/google/cel-spec.\n\nExample (Comparison):\n\n    title: \"Summary size limit\"\n    description: \"Determines if a summary is less than 100 chars\"\n    expression: \"document.summary.size() \u003c 100\"\n\nExample (Equality):\n\n    title: \"Requestor is owner\"\n    description: \"Determines if requestor is the document owner\"\n    expression: \"document.owner == request.auth.claims.email\"\n\nExample (Logic):\n\n    title: \"Public documents\"\n    description: \"Determine whether the document should be publicly visible\"\n    expression: \"document.type != 'private' \u0026\u0026 document.type != 'internal'\"\n\nExample (Data Manipulation):\n\n    title: \"Notification string\"\n    description: \"Create a notification string with a timestamp.\"\n    expression: \"'New message received at ' + string(document.create_time)\"\n\nThe exact variables and functions that may be referenced within an expression\nare determined by the service that evaluates it. See the service\ndocumentation for additional information.",
       "id": "Expr",
       "properties": {
         "description": {
-          "description": "An optional description of the expression. This is a longer text which\ndescribes the expression, e.g. when hovered over it in a UI.",
+          "description": "Optional. Description of the expression. This is a longer text which\ndescribes the expression, e.g. when hovered over it in a UI.",
           "type": "string"
         },
         "expression": {
-          "description": "Textual representation of an expression in\nCommon Expression Language syntax.\n\nThe application context of the containing message determines which\nwell-known feature set of CEL is supported.",
+          "description": "Textual representation of an expression in Common Expression Language\nsyntax.",
           "type": "string"
         },
         "location": {
-          "description": "An optional string indicating the location of the expression for error\nreporting, e.g. a file name and a position in the file.",
+          "description": "Optional. String indicating the location of the expression for error\nreporting, e.g. a file name and a position in the file.",
           "type": "string"
         },
         "title": {
-          "description": "An optional title for the expression, i.e. a short string describing\nits purpose. This can be used e.g. in UIs which allow to enter the\nexpression.",
+          "description": "Optional. Title for the expression, i.e. a short string describing\nits purpose. This can be used e.g. in UIs which allow to enter the\nexpression.",
           "type": "string"
         }
       },
@@ -856,7 +857,79 @@
     "GetIamPolicyRequest": {
       "description": "Request message for `GetIamPolicy` method.",
       "id": "GetIamPolicyRequest",
-      "properties": {},
+      "properties": {
+        "options": {
+          "$ref": "GetPolicyOptions",
+          "description": "OPTIONAL: A `GetPolicyOptions` object for specifying options to\n`GetIamPolicy`."
+        }
+      },
+      "type": "object"
+    },
+    "GetPolicyOptions": {
+      "description": "Encapsulates settings provided to GetIamPolicy.",
+      "id": "GetPolicyOptions",
+      "properties": {
+        "requestedPolicyVersion": {
+          "description": "Optional. The policy format version to be returned.\n\nValid values are 0, 1, and 3. Requests specifying an invalid value will be\nrejected.\n\nRequests for policies with any conditional bindings must specify version 3.\nPolicies without any conditional bindings may specify any valid value or\nleave the field unset.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM\ndocumentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "HttpRequest": {
+      "description": "HTTP request.\n\nThe task will be pushed to the worker as an HTTP request. If the worker\nor the redirected worker acknowledges the task by returning a successful HTTP\nresponse code ([`200` - `299`]), the task will be removed from the queue. If\nany other HTTP response code is returned or no response is received, the\ntask will be retried according to the following:\n\n* User-specified throttling: retry configuration,\n  rate limits, and the queue's state.\n\n* System throttling: To prevent the worker from overloading, Cloud Tasks may\n  temporarily reduce the queue's effective rate. User-specified settings\n  will not be changed.\n\n System throttling happens because:\n\n  * Cloud Tasks backs off on all errors. Normally the backoff specified in\n    rate limits will be used. But if the worker returns\n    `429` (Too Many Requests), `503` (Service Unavailable), or the rate of\n    errors is high, Cloud Tasks will use a higher backoff rate. The retry\n    specified in the `Retry-After` HTTP response header is considered.\n\n  * To prevent traffic spikes and to smooth sudden increases in traffic,\n    dispatches ramp up slowly when the queue is newly created or idle and\n    if large numbers of tasks suddenly become available to dispatch (due to\n    spikes in create task rates, the queue being unpaused, or many tasks\n    that are scheduled at the same time).",
+      "id": "HttpRequest",
+      "properties": {
+        "body": {
+          "description": "HTTP request body.\n\nA request body is allowed only if the\nHTTP method is POST, PUT, or PATCH. It is an\nerror to set body on a task with an incompatible HttpMethod.",
+          "format": "byte",
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "HTTP request headers.\n\nThis map contains the header field names and values.\nHeaders can be set when the\ntask is created.\n\nThese headers represent a subset of the headers that will accompany the\ntask's HTTP request. Some HTTP request headers will be ignored or replaced.\n\nA partial list of headers that will be ignored or replaced is:\n\n* Host: This will be computed by Cloud Tasks and derived from\n  HttpRequest.url.\n* Content-Length: This will be computed by Cloud Tasks.\n* User-Agent: This will be set to `\"Google-Cloud-Tasks\"`.\n* X-Google-*: Google use only.\n* X-AppEngine-*: Google use only.\n\n`Content-Type` won't be set by Cloud Tasks. You can explicitly set\n`Content-Type` to a media type when the\n task is created.\n For example, `Content-Type` can be set to `\"application/octet-stream\"` or\n `\"application/json\"`.\n\nHeaders which can have multiple values (according to RFC2616) can be\nspecified using comma-separated values.\n\nThe size of the headers must be less than 80KB.",
+          "type": "object"
+        },
+        "httpMethod": {
+          "description": "The HTTP method to use for the request. The default is POST.",
+          "enum": [
+            "HTTP_METHOD_UNSPECIFIED",
+            "POST",
+            "GET",
+            "HEAD",
+            "PUT",
+            "DELETE",
+            "PATCH",
+            "OPTIONS"
+          ],
+          "enumDescriptions": [
+            "HTTP method unspecified",
+            "HTTP POST",
+            "HTTP GET",
+            "HTTP HEAD",
+            "HTTP PUT",
+            "HTTP DELETE",
+            "HTTP PATCH",
+            "HTTP OPTIONS"
+          ],
+          "type": "string"
+        },
+        "oauthToken": {
+          "$ref": "OAuthToken",
+          "description": "If specified, an\n[OAuth token](https://developers.google.com/identity/protocols/OAuth2)\nwill be generated and attached as an `Authorization` header in the HTTP\nrequest.\n\nThis type of authorization should generally only be used when calling\nGoogle APIs hosted on *.googleapis.com."
+        },
+        "oidcToken": {
+          "$ref": "OidcToken",
+          "description": "If specified, an\n[OIDC](https://developers.google.com/identity/protocols/OpenIDConnect)\ntoken will be generated and attached as an `Authorization` header in the\nHTTP request.\n\nThis type of authorization can be used for many scenarios, including\ncalling Cloud Run, or endpoints where you intend to validate the token\nyourself."
+        },
+        "url": {
+          "description": "Required. The full url path that the request will be sent to.\n\nThis string must begin with either \"http://\" or \"https://\". Some examples\nare: `http://acme.com` and `https://acme.com/sales:8080`. Cloud Tasks will\nencode some characters for safety and compatibility. The maximum allowed\nURL length is 2083 characters after encoding.\n\nThe `Location` header response from a redirect response [`300` - `399`]\nmay be followed. The redirect is not counted as a separate attempt.",
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "ListLocationsResponse": {
@@ -947,6 +1020,36 @@
       },
       "type": "object"
     },
+    "OAuthToken": {
+      "description": "Contains information needed for generating an\n[OAuth token](https://developers.google.com/identity/protocols/OAuth2).\nThis type of authorization should generally only be used when calling Google\nAPIs hosted on *.googleapis.com.",
+      "id": "OAuthToken",
+      "properties": {
+        "scope": {
+          "description": "OAuth scope to be used for generating OAuth access token.\nIf not specified, \"https://www.googleapis.com/auth/cloud-platform\"\nwill be used.",
+          "type": "string"
+        },
+        "serviceAccountEmail": {
+          "description": "[Service account email](https://cloud.google.com/iam/docs/service-accounts)\nto be used for generating OAuth token.\nThe service account must be within the same project as the queue. The\ncaller must have iam.serviceAccounts.actAs permission for the service\naccount.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "OidcToken": {
+      "description": "Contains information needed for generating an\n[OpenID Connect\ntoken](https://developers.google.com/identity/protocols/OpenIDConnect).\nThis type of authorization can be used for many scenarios, including\ncalling Cloud Run, or endpoints where you intend to validate the token\nyourself.",
+      "id": "OidcToken",
+      "properties": {
+        "audience": {
+          "description": "Audience to be used when generating OIDC token. If not specified, the URI\nspecified in target will be used.",
+          "type": "string"
+        },
+        "serviceAccountEmail": {
+          "description": "[Service account email](https://cloud.google.com/iam/docs/service-accounts)\nto be used for generating OIDC token.\nThe service account must be within the same project as the queue. The\ncaller must have iam.serviceAccounts.actAs permission for the service\naccount.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "PauseQueueRequest": {
       "description": "Request message for PauseQueue.",
       "id": "PauseQueueRequest",
@@ -954,23 +1057,23 @@
       "type": "object"
     },
     "Policy": {
-      "description": "Defines an Identity and Access Management (IAM) policy. It is used to\nspecify access control policies for Cloud Platform resources.\n\n\nA `Policy` consists of a list of `bindings`. A `binding` binds a list of\n`members` to a `role`, where the members can be user accounts, Google groups,\nGoogle domains, and service accounts. A `role` is a named list of permissions\ndefined by IAM.\n\n**JSON Example**\n\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/owner\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-other-app@appspot.gserviceaccount.com\"\n          ]\n        },\n        {\n          \"role\": \"roles/viewer\",\n          \"members\": [\"user:sean@example.com\"]\n        }\n      ]\n    }\n\n**YAML Example**\n\n    bindings:\n    - members:\n      - user:mike@example.com\n      - group:admins@example.com\n      - domain:google.com\n      - serviceAccount:my-other-app@appspot.gserviceaccount.com\n      role: roles/owner\n    - members:\n      - user:sean@example.com\n      role: roles/viewer\n\n\nFor a description of IAM and its features, see the\n[IAM developer's guide](https://cloud.google.com/iam/docs).",
+      "description": "An Identity and Access Management (IAM) policy, which specifies access\ncontrols for Google Cloud resources.\n\n\nA `Policy` is a collection of `bindings`. A `binding` binds one or more\n`members` to a single `role`. Members can be user accounts, service accounts,\nGoogle groups, and domains (such as G Suite). A `role` is a named list of\npermissions; each `role` can be an IAM predefined role or a user-created\ncustom role.\n\nFor some types of Google Cloud resources, a `binding` can also specify a\n`condition`, which is a logical expression that allows access to a resource\nonly if the expression evaluates to `true`. A condition can add constraints\nbased on attributes of the request, the resource, or both. To learn which\nresources support conditions in their IAM policies, see the\n[IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).\n\n**JSON example:**\n\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/resourcemanager.organizationAdmin\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-project-id@appspot.gserviceaccount.com\"\n          ]\n        },\n        {\n          \"role\": \"roles/resourcemanager.organizationViewer\",\n          \"members\": [\n            \"user:eve@example.com\"\n          ],\n          \"condition\": {\n            \"title\": \"expirable access\",\n            \"description\": \"Does not grant access after Sep 2020\",\n            \"expression\": \"request.time \u003c timestamp('2020-10-01T00:00:00.000Z')\",\n          }\n        }\n      ],\n      \"etag\": \"BwWWja0YfJA=\",\n      \"version\": 3\n    }\n\n**YAML example:**\n\n    bindings:\n    - members:\n      - user:mike@example.com\n      - group:admins@example.com\n      - domain:google.com\n      - serviceAccount:my-project-id@appspot.gserviceaccount.com\n      role: roles/resourcemanager.organizationAdmin\n    - members:\n      - user:eve@example.com\n      role: roles/resourcemanager.organizationViewer\n      condition:\n        title: expirable access\n        description: Does not grant access after Sep 2020\n        expression: request.time \u003c timestamp('2020-10-01T00:00:00.000Z')\n    - etag: BwWWja0YfJA=\n    - version: 3\n\nFor a description of IAM and its features, see the\n[IAM documentation](https://cloud.google.com/iam/docs/).",
       "id": "Policy",
       "properties": {
         "bindings": {
-          "description": "Associates a list of `members` to a `role`.\n`bindings` with no members will result in an error.",
+          "description": "Associates a list of `members` to a `role`. Optionally, may specify a\n`condition` that determines how and when the `bindings` are applied. Each\nof the `bindings` must contain at least one member.",
           "items": {
             "$ref": "Binding"
           },
           "type": "array"
         },
         "etag": {
-          "description": "`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\nIf no `etag` is provided in the call to `setIamPolicy`, then the existing\npolicy is overwritten blindly.",
+          "description": "`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\n**Important:** If you use IAM Conditions, you must include the `etag` field\nwhenever you call `setIamPolicy`. If you omit this field, then IAM allows\nyou to overwrite a version `3` policy with a version `1` policy, and all of\nthe conditions in the version `3` policy are lost.",
           "format": "byte",
           "type": "string"
         },
         "version": {
-          "description": "Deprecated.",
+          "description": "Specifies the format of the policy.\n\nValid values are `0`, `1`, and `3`. Requests that specify an invalid value\nare rejected.\n\nAny operation that affects conditional role bindings must specify version\n`3`. This requirement applies to the following operations:\n\n* Getting a policy that includes a conditional role binding\n* Adding a conditional role binding to a policy\n* Changing a conditional role binding in a policy\n* Removing any role binding, with or without a condition, from a policy\n  that includes conditions\n\n**Important:** If you use IAM Conditions, you must include the `etag` field\nwhenever you call `setIamPolicy`. If you omit this field, then IAM allows\nyou to overwrite a version `3` policy with a version `1` policy, and all of\nthe conditions in the version `3` policy are lost.\n\nIf a policy does not include any conditions, operations on that policy may\nspecify any valid version or leave the field unset.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
           "format": "int32",
           "type": "integer"
         }
@@ -989,7 +1092,7 @@
       "properties": {
         "appEngineRoutingOverride": {
           "$ref": "AppEngineRouting",
-          "description": "Overrides for\ntask-level app_engine_routing.\nThese settings apply only to\nApp Engine tasks in this queue.\n\nIf set, `app_engine_routing_override` is used for all\nApp Engine tasks in the queue, no matter what the\nsetting is for the\ntask-level app_engine_routing."
+          "description": "Overrides for\ntask-level app_engine_routing.\nThese settings apply only to\nApp Engine tasks in this queue.\nHttp tasks are not affected.\n\nIf set, `app_engine_routing_override` is used for all\nApp Engine tasks in the queue, no matter what the\nsetting is for the\ntask-level app_engine_routing."
         },
         "name": {
           "description": "Caller-specified and required in CreateQueue,\nafter which it becomes output only.\n\nThe queue name.\n\nThe queue name must have the following format:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`\n\n* `PROJECT_ID` can contain letters ([A-Za-z]), numbers ([0-9]),\n   hyphens (-), colons (:), or periods (.).\n   For more information, see\n   [Identifying\n   projects](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects)\n* `LOCATION_ID` is the canonical ID for the queue's location.\n   The list of available locations can be obtained by calling\n   ListLocations.\n   For more information, see https://cloud.google.com/about/locations/.\n* `QUEUE_ID` can contain letters ([A-Za-z]), numbers ([0-9]), or\n  hyphens (-). The maximum length is 100 characters.",
@@ -1007,6 +1110,10 @@
         "retryConfig": {
           "$ref": "RetryConfig",
           "description": "Settings that determine the retry behavior.\n\n* For tasks created using Cloud Tasks: the queue-level retry settings\n  apply to all tasks in the queue that were created using Cloud Tasks.\n  Retry settings cannot be set on individual tasks.\n* For tasks created using the App Engine SDK: the queue-level retry\n  settings apply to all tasks in the queue which do not have retry settings\n  explicitly set on the task and were created by the App Engine SDK. See\n  [App Engine\n  documentation](https://cloud.google.com/appengine/docs/standard/python/taskqueue/push/retrying-tasks)."
+        },
+        "stackdriverLoggingConfig": {
+          "$ref": "StackdriverLoggingConfig",
+          "description": "Configuration options for writing logs to\n[Stackdriver Logging](https://cloud.google.com/logging/docs/). If this\nfield is unset, then no logs are written."
         },
         "state": {
           "description": "Output only. The state of the queue.\n\n`state` can only be changed by called\nPauseQueue,\nResumeQueue, or uploading\n[queue.yaml/xml](https://cloud.google.com/appengine/docs/python/config/queueref).\nUpdateQueue cannot be used to change `state`.",
@@ -1032,7 +1139,7 @@
       "id": "RateLimits",
       "properties": {
         "maxBurstSize": {
-          "description": "Output only. The max burst size.\n\nMax burst size limits how fast tasks in queue are processed when\nmany tasks are in the queue and the rate is high. This field\nallows the queue to have a high rate so processing starts shortly\nafter a task is enqueued, but still limits resource usage when\nmany tasks are enqueued in a short period of time.\n\nThe [token bucket](https://wikipedia.org/wiki/Token_Bucket)\nalgorithm is used to control the rate of task dispatches. Each\nqueue has a token bucket that holds tokens, up to the maximum\nspecified by `max_burst_size`. Each time a task is dispatched, a\ntoken is removed from the bucket. Tasks will be dispatched until\nthe queue's bucket runs out of tokens. The bucket will be\ncontinuously refilled with new tokens based on\nmax_dispatches_per_second.\n\nCloud Tasks will pick the value of `max_burst_size` based on the\nvalue of\nmax_dispatches_per_second.\n\nFor App Engine queues that were created or updated using\n`queue.yaml/xml`, `max_burst_size` is equal to\n[bucket_size](https://cloud.google.com/appengine/docs/standard/python/config/queueref#bucket_size).\nSince `max_burst_size` is output only, if\nUpdateQueue is called on a queue\ncreated by `queue.yaml/xml`, `max_burst_size` will be reset based\non the value of\nmax_dispatches_per_second,\nregardless of whether\nmax_dispatches_per_second\nis updated.\n",
+          "description": "Output only. The max burst size.\n\nMax burst size limits how fast tasks in queue are processed when\nmany tasks are in the queue and the rate is high. This field\nallows the queue to have a high rate so processing starts shortly\nafter a task is enqueued, but still limits resource usage when\nmany tasks are enqueued in a short period of time.\n\nThe [token bucket](https://wikipedia.org/wiki/Token_Bucket)\nalgorithm is used to control the rate of task dispatches. Each\nqueue has a token bucket that holds tokens, up to the maximum\nspecified by `max_burst_size`. Each time a task is dispatched, a\ntoken is removed from the bucket. Tasks will be dispatched until\nthe queue's bucket runs out of tokens. The bucket will be\ncontinuously refilled with new tokens based on\nmax_dispatches_per_second.\n\nCloud Tasks will pick the value of `max_burst_size` based on the\nvalue of\nmax_dispatches_per_second.\n\nFor queues that were created or updated using\n`queue.yaml/xml`, `max_burst_size` is equal to\n[bucket_size](https://cloud.google.com/appengine/docs/standard/python/config/queueref#bucket_size).\nSince `max_burst_size` is output only, if\nUpdateQueue is called on a queue\ncreated by `queue.yaml/xml`, `max_burst_size` will be reset based\non the value of\nmax_dispatches_per_second,\nregardless of whether\nmax_dispatches_per_second\nis updated.\n",
           "format": "int32",
           "type": "integer"
         },
@@ -1042,7 +1149,7 @@
           "type": "integer"
         },
         "maxDispatchesPerSecond": {
-          "description": "The maximum rate at which tasks are dispatched from this queue.\n\nIf unspecified when the queue is created, Cloud Tasks will pick the\ndefault.\n\n* For App Engine queues, the maximum allowed value\n  is 500.\n\n\nThis field has the same meaning as\n[rate in\nqueue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#rate).",
+          "description": "The maximum rate at which tasks are dispatched from this queue.\n\nIf unspecified when the queue is created, Cloud Tasks will pick the\ndefault.\n\n* The maximum allowed value is 500.\n\n\nThis field has the same meaning as\n[rate in\nqueue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#rate).",
           "format": "double",
           "type": "number"
         }
@@ -1070,7 +1177,7 @@
           "type": "string"
         },
         "maxDoublings": {
-          "description": "The time between retries will double `max_doublings` times.\n\nA task's retry interval starts at\nmin_backoff, then doubles\n`max_doublings` times, then increases linearly, and finally\nretries retries at intervals of\nmax_backoff up to\nmax_attempts times.\n\nFor example, if min_backoff is 10s,\nmax_backoff is 300s, and\n`max_doublings` is 3, then the a task will first be retried in\n10s. The retry interval will double three times, and then\nincrease linearly by 2^3 * 10s.  Finally, the task will retry at\nintervals of max_backoff until the\ntask has been attempted max_attempts\ntimes. Thus, the requests will retry at 10s, 20s, 40s, 80s, 160s,\n240s, 300s, 300s, ....\n\nIf unspecified when the queue is created, Cloud Tasks will pick the\ndefault.\n\n\nThis field has the same meaning as\n[max_doublings in\nqueue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).",
+          "description": "The time between retries will double `max_doublings` times.\n\nA task's retry interval starts at\nmin_backoff, then doubles\n`max_doublings` times, then increases linearly, and finally\nretries at intervals of\nmax_backoff up to\nmax_attempts times.\n\nFor example, if min_backoff is 10s,\nmax_backoff is 300s, and\n`max_doublings` is 3, then the a task will first be retried in\n10s. The retry interval will double three times, and then\nincrease linearly by 2^3 * 10s.  Finally, the task will retry at\nintervals of max_backoff until the\ntask has been attempted max_attempts\ntimes. Thus, the requests will retry at 10s, 20s, 40s, 80s, 160s,\n240s, 300s, 300s, ....\n\nIf unspecified when the queue is created, Cloud Tasks will pick the\ndefault.\n\n\nThis field has the same meaning as\n[max_doublings in\nqueue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).",
           "format": "int32",
           "type": "integer"
         },
@@ -1119,8 +1226,20 @@
       },
       "type": "object"
     },
+    "StackdriverLoggingConfig": {
+      "description": "Configuration options for writing logs to\n[Stackdriver Logging](https://cloud.google.com/logging/docs/).",
+      "id": "StackdriverLoggingConfig",
+      "properties": {
+        "samplingRatio": {
+          "description": "Specifies the fraction of operations to write to\n[Stackdriver Logging](https://cloud.google.com/logging/docs/).\nThis field may contain any value between 0.0 and 1.0, inclusive.\n0.0 is the default and means that no operations are logged.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
     "Status": {
-      "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). The error model is designed to be:\n\n- Simple to use and understand for most users\n- Flexible enough to meet unexpected needs\n\n# Overview\n\nThe `Status` message contains three pieces of data: error code, error\nmessage, and error details. The error code should be an enum value of\ngoogle.rpc.Code, but it may accept additional error codes if needed.  The\nerror message should be a developer-facing English message that helps\ndevelopers *understand* and *resolve* the error. If a localized user-facing\nerror message is needed, put the localized message in the error details or\nlocalize it in the client. The optional error details may contain arbitrary\ninformation about the error. There is a predefined set of error detail types\nin the package `google.rpc` that can be used for common error conditions.\n\n# Language mapping\n\nThe `Status` message is the logical representation of the error model, but it\nis not necessarily the actual wire format. When the `Status` message is\nexposed in different client libraries and different wire protocols, it can be\nmapped differently. For example, it will likely be mapped to some exceptions\nin Java, but more likely mapped to some error codes in C.\n\n# Other uses\n\nThe error model and the `Status` message can be used in a variety of\nenvironments, either with or without APIs, to provide a\nconsistent developer experience across different environments.\n\nExample uses of this error model include:\n\n- Partial errors. If a service needs to return partial errors to the client,\n    it may embed the `Status` in the normal response to indicate the partial\n    errors.\n\n- Workflow errors. A typical workflow has multiple steps. Each step may\n    have a `Status` message for error reporting.\n\n- Batch operations. If a client uses batch request and batch response, the\n    `Status` message should be used directly inside batch response, one for\n    each error sub-response.\n\n- Asynchronous operations. If an API call embeds asynchronous operation\n    results in its response, the status of those operations should be\n    represented directly using the `Status` message.\n\n- Logging. If some API errors are stored in logs, the message `Status` could\n    be used directly after any stripping needed for security/privacy reasons.",
+      "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors).",
       "id": "Status",
       "properties": {
         "code": {
@@ -1165,13 +1284,17 @@
           "type": "integer"
         },
         "dispatchDeadline": {
-          "description": "The deadline for requests sent to the worker. If the worker does not\nrespond by this deadline then the request is cancelled and the attempt\nis marked as a `DEADLINE_EXCEEDED` failure. Cloud Tasks will retry the\ntask according to the RetryConfig.\n\nNote that when the request is cancelled, Cloud Tasks will stop listing for\nthe response, but whether the worker stops processing depends on the\nworker. For example, if the worker is stuck, it may not react to cancelled\nrequests.\n\nThe default and maximum values depend on the type of request:\n\n\n* For App Engine tasks, 0 indicates that the\n  request has the default deadline. The default deadline depends on the\n  [scaling\n  type](https://cloud.google.com/appengine/docs/standard/go/how-instances-are-managed#instance_scaling)\n  of the service: 10 minutes for standard apps with automatic scaling, 24\n  hours for standard apps with manual and basic scaling, and 60 minutes for\n  flex apps. If the request deadline is set, it must be in the interval [15\n  seconds, 24 hours 15 seconds]. Regardless of the task's\n  `dispatch_deadline`, the app handler will not run for longer than than\n  the service's timeout. We recommend setting the `dispatch_deadline` to\n  at most a few seconds more than the app handler's timeout. For more\n  information see\n  [Timeouts](https://cloud.google.com/tasks/docs/creating-appengine-handlers#timeouts).\n\n`dispatch_deadline` will be truncated to the nearest millisecond. The\ndeadline is an approximate deadline.",
+          "description": "The deadline for requests sent to the worker. If the worker does not\nrespond by this deadline then the request is cancelled and the attempt\nis marked as a `DEADLINE_EXCEEDED` failure. Cloud Tasks will retry the\ntask according to the RetryConfig.\n\nNote that when the request is cancelled, Cloud Tasks will stop listening\nfor the response, but whether the worker stops processing depends on the\nworker. For example, if the worker is stuck, it may not react to cancelled\nrequests.\n\nThe default and maximum values depend on the type of request:\n\n* For HTTP tasks, the default is 10 minutes. The deadline\n  must be in the interval [15 seconds, 30 minutes].\n\n* For App Engine tasks, 0 indicates that the\n  request has the default deadline. The default deadline depends on the\n  [scaling\n  type](https://cloud.google.com/appengine/docs/standard/go/how-instances-are-managed#instance_scaling)\n  of the service: 10 minutes for standard apps with automatic scaling, 24\n  hours for standard apps with manual and basic scaling, and 60 minutes for\n  flex apps. If the request deadline is set, it must be in the interval [15\n  seconds, 24 hours 15 seconds]. Regardless of the task's\n  `dispatch_deadline`, the app handler will not run for longer than than\n  the service's timeout. We recommend setting the `dispatch_deadline` to\n  at most a few seconds more than the app handler's timeout. For more\n  information see\n  [Timeouts](https://cloud.google.com/tasks/docs/creating-appengine-handlers#timeouts).\n\n`dispatch_deadline` will be truncated to the nearest millisecond. The\ndeadline is an approximate deadline.",
           "format": "google-duration",
           "type": "string"
         },
         "firstAttempt": {
           "$ref": "Attempt",
           "description": "Output only. The status of the task's first attempt.\n\nOnly dispatch_time will be set.\nThe other Attempt information is not retained by Cloud Tasks."
+        },
+        "httpRequest": {
+          "$ref": "HttpRequest",
+          "description": "HTTP request that is sent to the worker.\n\nAn HTTP task is a task that has HttpRequest set."
         },
         "lastAttempt": {
           "$ref": "Attempt",
@@ -1187,7 +1310,7 @@
           "type": "integer"
         },
         "scheduleTime": {
-          "description": "The time when the task is scheduled to be attempted.\n\nFor App Engine queues, this is when the task will be attempted or retried.\n\n`schedule_time` will be truncated to the nearest microsecond.",
+          "description": "The time when the task is scheduled to be attempted or retried.\n\n`schedule_time` will be truncated to the nearest microsecond.",
           "format": "google-datetime",
           "type": "string"
         },

--- a/gen/model/cloudtasks/v2beta2/cloudtasks-api.json
+++ b/gen/model/cloudtasks/v2beta2/cloudtasks-api.json
@@ -22,6 +22,7 @@
   },
   "id": "cloudtasks:v2beta2",
   "kind": "discovery#restDescription",
+  "mtlsRootUrl": "https://cloudtasks.mtls.googleapis.com/",
   "name": "cloudtasks",
   "ownerDomain": "google.com",
   "ownerName": "Google",
@@ -188,7 +189,7 @@
                   ],
                   "parameters": {
                     "parent": {
-                      "description": "Required.\n\nThe location name in which the queue will be created.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`\n\nThe list of allowed locations can be obtained by calling Cloud\nTasks' implementation of\nListLocations.",
+                      "description": "Required. The location name in which the queue will be created.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`\n\nThe list of allowed locations can be obtained by calling Cloud\nTasks' implementation of\nListLocations.",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+$",
                       "required": true,
@@ -216,7 +217,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -241,10 +242,16 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe resource name of the queue. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The resource name of the queue. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
+                      "type": "string"
+                    },
+                    "readMask": {
+                      "description": "Optional. Read mask is used for a more granular control over what the API returns. By\nit includes all fields in Queue except for stats.",
+                      "format": "google-fieldmask",
+                      "location": "query",
                       "type": "string"
                     }
                   },
@@ -310,7 +317,7 @@
                       "type": "string"
                     },
                     "parent": {
-                      "description": "Required.\n\nThe location name.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`",
+                      "description": "Required. The location name.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+$",
                       "required": true,
@@ -369,7 +376,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -397,7 +404,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -425,7 +432,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -513,7 +520,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -541,7 +548,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -569,7 +576,7 @@
                       ],
                       "parameters": {
                         "parent": {
-                          "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`\n\nThe queue must already exist.",
+                          "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`\n\nThe queue must already exist.",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                           "required": true,
@@ -597,7 +604,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -622,7 +629,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -657,7 +664,7 @@
                       ],
                       "parameters": {
                         "parent": {
-                          "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                          "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                           "required": true,
@@ -685,7 +692,7 @@
                       ],
                       "parameters": {
                         "pageSize": {
-                          "description": "Requested page size. Fewer tasks than requested might be returned.\n\nThe maximum page size is 1000. If unspecified, the page size will\nbe the maximum. Fewer tasks than requested might be returned,\neven if more tasks exist; use\nnext_page_token in the\nresponse to determine if more tasks exist.",
+                          "description": "Maximum page size.\n\nFewer tasks than requested might be returned, even if more tasks exist; use\nnext_page_token in the response to\ndetermine if more tasks exist.\n\nThe maximum page size is 1000. If unspecified, the page size will be the\nmaximum.",
                           "format": "int32",
                           "location": "query",
                           "type": "integer"
@@ -696,7 +703,7 @@
                           "type": "string"
                         },
                         "parent": {
-                          "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                          "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                           "required": true,
@@ -731,7 +738,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -759,7 +766,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -786,7 +793,7 @@
       }
     }
   },
-  "revision": "20190412",
+  "revision": "20200505",
   "rootUrl": "https://cloudtasks.googleapis.com/",
   "schemas": {
     "AcknowledgeTaskRequest": {
@@ -794,7 +801,7 @@
       "id": "AcknowledgeTaskRequest",
       "properties": {
         "scheduleTime": {
-          "description": "Required.\n\nThe task's current schedule time, available in the\nschedule_time returned by\nLeaseTasks response or\nRenewLease response. This restriction is\nto ensure that your worker currently holds the lease.",
+          "description": "Required. The task's current schedule time, available in the\nschedule_time returned by\nLeaseTasks response or\nRenewLease response. This restriction is\nto ensure that your worker currently holds the lease.",
           "format": "google-datetime",
           "type": "string"
         }
@@ -802,7 +809,7 @@
       "type": "object"
     },
     "AppEngineHttpRequest": {
-      "description": "App Engine HTTP request.\n\nThe message defines the HTTP request that is sent to an App Engine app when\nthe task is dispatched.\n\nThis proto can only be used for tasks in a queue which has\napp_engine_http_target set.\n\nUsing AppEngineHttpRequest requires\n[`appengine.applications.get`](https://cloud.google.com/appengine/docs/admin-api/access-control)\nGoogle IAM permission for the project\nand the following scope:\n\n`https://www.googleapis.com/auth/cloud-platform`\n\nThe task will be delivered to the App Engine app which belongs to the same\nproject as the queue. For more information, see\n[How Requests are\nRouted](https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed)\nand how routing is affected by\n[dispatch\nfiles](https://cloud.google.com/appengine/docs/python/config/dispatchref).\nTraffic is encrypted during transport and never leaves Google datacenters.\nBecause this traffic is carried over a communication mechanism internal to\nGoogle, you cannot explicitly set the protocol (for example, HTTP or HTTPS).\nThe request to the handler, however, will appear to have used the HTTP\nprotocol.\n\nThe AppEngineRouting used to construct the URL that the task is\ndelivered to can be set at the queue-level or task-level:\n\n* If set,\n   app_engine_routing_override\n   is used for all tasks in the queue, no matter what the setting\n   is for the\n   task-level app_engine_routing.\n\n\nThe `url` that the task will be sent to is:\n\n* `url =` host `+`\n  relative_url\n\nTasks can be dispatched to secure app handlers, unsecure app handlers, and\nURIs restricted with\n[`login:\nadmin`](https://cloud.google.com/appengine/docs/standard/python/config/appref).\nBecause tasks are not run as any user, they cannot be dispatched to URIs\nrestricted with\n[`login:\nrequired`](https://cloud.google.com/appengine/docs/standard/python/config/appref)\nTask dispatches also do not follow redirects.\n\nThe task attempt has succeeded if the app's request handler returns\nan HTTP response code in the range [`200` - `299`]. `503` is\nconsidered an App Engine system error instead of an application\nerror. Requests returning error `503` will be retried regardless of\nretry configuration and not counted against retry counts.\nAny other response code or a failure to receive a response before the\ndeadline is a failed attempt.",
+      "description": "App Engine HTTP request.\n\nThe message defines the HTTP request that is sent to an App Engine app when\nthe task is dispatched.\n\nThis proto can only be used for tasks in a queue which has\napp_engine_http_target set.\n\nUsing AppEngineHttpRequest requires\n[`appengine.applications.get`](https://cloud.google.com/appengine/docs/admin-api/access-control)\nGoogle IAM permission for the project\nand the following scope:\n\n`https://www.googleapis.com/auth/cloud-platform`\n\nThe task will be delivered to the App Engine app which belongs to the same\nproject as the queue. For more information, see\n[How Requests are\nRouted](https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed)\nand how routing is affected by\n[dispatch\nfiles](https://cloud.google.com/appengine/docs/python/config/dispatchref).\nTraffic is encrypted during transport and never leaves Google datacenters.\nBecause this traffic is carried over a communication mechanism internal to\nGoogle, you cannot explicitly set the protocol (for example, HTTP or HTTPS).\nThe request to the handler, however, will appear to have used the HTTP\nprotocol.\n\nThe AppEngineRouting used to construct the URL that the task is\ndelivered to can be set at the queue-level or task-level:\n\n* If set,\n  app_engine_routing_override\n  is used for all tasks in the queue, no matter what the setting\n  is for the\n  task-level app_engine_routing.\n\n\nThe `url` that the task will be sent to is:\n\n* `url =` host `+`\n  relative_url\n\nTasks can be dispatched to secure app handlers, unsecure app handlers, and\nURIs restricted with\n[`login:\nadmin`](https://cloud.google.com/appengine/docs/standard/python/config/appref).\nBecause tasks are not run as any user, they cannot be dispatched to URIs\nrestricted with\n[`login:\nrequired`](https://cloud.google.com/appengine/docs/standard/python/config/appref)\nTask dispatches also do not follow redirects.\n\nThe task attempt has succeeded if the app's request handler returns an HTTP\nresponse code in the range [`200` - `299`]. The task attempt has failed if\nthe app's handler returns a non-2xx response code or Cloud Tasks does\nnot receive response before the deadline. Failed\ntasks will be retried according to the\nretry configuration. `503` (Service Unavailable) is\nconsidered an App Engine system error instead of an application error and\nwill cause Cloud Tasks' traffic congestion control to temporarily throttle\nthe queue's dispatches. Unlike other types of task targets, a `429` (Too Many\nRequests) response from an app handler does not cause traffic congestion\ncontrol to throttle the queue.",
       "id": "AppEngineHttpRequest",
       "properties": {
         "appEngineRouting": {
@@ -817,7 +824,7 @@
           "type": "object"
         },
         "httpMethod": {
-          "description": "The HTTP method to use for the request. The default is POST.\n\nThe app's request handler for the task's target URL must be able to handle\nHTTP requests with this http_method, otherwise the task attempt will fail\nwith error code 405 (Method Not Allowed). See\n[Writing a push task request\nhandler](https://cloud.google.com/appengine/docs/java/taskqueue/push/creating-handlers#writing_a_push_task_request_handler)\nand the documentation for the request handlers in the language your app is\nwritten in e.g.\n[Python Request\nHandler](https://cloud.google.com/appengine/docs/python/tools/webapp/requesthandlerclass).",
+          "description": "The HTTP method to use for the request. The default is POST.\n\nThe app's request handler for the task's target URL must be able to handle\nHTTP requests with this http_method, otherwise the task attempt fails with\nerror code 405 (Method Not Allowed). See [Writing a push task request\nhandler](https://cloud.google.com/appengine/docs/java/taskqueue/push/creating-handlers#writing_a_push_task_request_handler)\nand the App Engine documentation for your runtime on [How Requests are\nHandled](https://cloud.google.com/appengine/docs/standard/python3/how-requests-are-handled).",
           "enum": [
             "HTTP_METHOD_UNSPECIFIED",
             "POST",
@@ -914,10 +921,10 @@
       "properties": {
         "condition": {
           "$ref": "Expr",
-          "description": "The condition that is associated with this binding.\nNOTE: An unsatisfied condition will not allow user access via current\nbinding. Different bindings, including their conditions, are examined\nindependently."
+          "description": "The condition that is associated with this binding.\n\nIf the condition evaluates to `true`, then this binding applies to the\ncurrent request.\n\nIf the condition evaluates to `false`, then this binding does not apply to\nthe current request. However, a different role binding might grant the same\nrole to one or more of the members in this binding.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM\ndocumentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
         },
         "members": {
-          "description": "Specifies the identities requesting access for a Cloud Platform resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@gmail.com` .\n\n\n* `serviceAccount:{emailid}`: An email address that represents a service\n   account. For example, `my-other-app@appspot.gserviceaccount.com`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n\n* `domain:{domain}`: The G Suite domain (primary) that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n",
+          "description": "Specifies the identities requesting access for a Cloud Platform resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@example.com` .\n\n\n* `serviceAccount:{emailid}`: An email address that represents a service\n   account. For example, `my-other-app@appspot.gserviceaccount.com`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n* `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique\n   identifier) representing a user that has been recently deleted. For\n   example, `alice@example.com?uid=123456789012345678901`. If the user is\n   recovered, this value reverts to `user:{emailid}` and the recovered user\n   retains the role in the binding.\n\n* `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus\n   unique identifier) representing a service account that has been recently\n   deleted. For example,\n   `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`.\n   If the service account is undeleted, this value reverts to\n   `serviceAccount:{emailid}` and the undeleted service account retains the\n   role in the binding.\n\n* `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique\n   identifier) representing a Google group that has been recently\n   deleted. For example, `admins@example.com?uid=123456789012345678901`. If\n   the group is recovered, this value reverts to `group:{emailid}` and the\n   recovered group retains the role in the binding.\n\n\n* `domain:{domain}`: The G Suite domain (primary) that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n",
           "items": {
             "type": "string"
           },
@@ -949,7 +956,7 @@
           "type": "string"
         },
         "scheduleTime": {
-          "description": "Required.\n\nThe task's current schedule time, available in the\nschedule_time returned by\nLeaseTasks response or\nRenewLease response. This restriction is\nto ensure that your worker currently holds the lease.",
+          "description": "Required. The task's current schedule time, available in the\nschedule_time returned by\nLeaseTasks response or\nRenewLease response. This restriction is\nto ensure that your worker currently holds the lease.",
           "format": "google-datetime",
           "type": "string"
         }
@@ -976,7 +983,7 @@
         },
         "task": {
           "$ref": "Task",
-          "description": "Required.\n\nThe task to add.\n\nTask names have the following format:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.\nThe user can optionally specify a task name. If a\nname is not specified then the system will generate a random\nunique task id, which will be set in the task returned in the\nresponse.\n\nIf schedule_time is not set or is in the\npast then Cloud Tasks will set it to the current time.\n\nTask De-duplication:\n\nExplicitly specifying a task ID enables task de-duplication.  If\na task's ID is identical to that of an existing task or a task\nthat was deleted or completed recently then the call will fail\nwith ALREADY_EXISTS.\nIf the task's queue was created using Cloud Tasks, then another task with\nthe same name can't be created for ~1hour after the original task was\ndeleted or completed. If the task's queue was created using queue.yaml or\nqueue.xml, then another task with the same name can't be created\nfor ~9days after the original task was deleted or completed.\n\nBecause there is an extra lookup cost to identify duplicate task\nnames, these CreateTask calls have significantly\nincreased latency. Using hashed strings for the task id or for\nthe prefix of the task id is recommended. Choosing task ids that\nare sequential or have sequential prefixes, for example using a\ntimestamp, causes an increase in latency and error rates in all\ntask commands. The infrastructure relies on an approximately\nuniform distribution of task ids to store and serve tasks\nefficiently."
+          "description": "Required. The task to add.\n\nTask names have the following format:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.\nThe user can optionally specify a task name. If a\nname is not specified then the system will generate a random\nunique task id, which will be set in the task returned in the\nresponse.\n\nIf schedule_time is not set or is in the\npast then Cloud Tasks will set it to the current time.\n\nTask De-duplication:\n\nExplicitly specifying a task ID enables task de-duplication.  If\na task's ID is identical to that of an existing task or a task\nthat was deleted or completed recently then the call will fail\nwith ALREADY_EXISTS.\nIf the task's queue was created using Cloud Tasks, then another task with\nthe same name can't be created for ~1hour after the original task was\ndeleted or completed. If the task's queue was created using queue.yaml or\nqueue.xml, then another task with the same name can't be created\nfor ~9days after the original task was deleted or completed.\n\nBecause there is an extra lookup cost to identify duplicate task\nnames, these CreateTask calls have significantly\nincreased latency. Using hashed strings for the task id or for\nthe prefix of the task id is recommended. Choosing task ids that\nare sequential or have sequential prefixes, for example using a\ntimestamp, causes an increase in latency and error rates in all\ntask commands. The infrastructure relies on an approximately\nuniform distribution of task ids to store and serve tasks\nefficiently."
         }
       },
       "type": "object"
@@ -988,23 +995,23 @@
       "type": "object"
     },
     "Expr": {
-      "description": "Represents an expression text. Example:\n\n    title: \"User account presence\"\n    description: \"Determines whether the request has a user account\"\n    expression: \"size(request.user) \u003e 0\"",
+      "description": "Represents a textual expression in the Common Expression Language (CEL)\nsyntax. CEL is a C-like expression language. The syntax and semantics of CEL\nare documented at https://github.com/google/cel-spec.\n\nExample (Comparison):\n\n    title: \"Summary size limit\"\n    description: \"Determines if a summary is less than 100 chars\"\n    expression: \"document.summary.size() \u003c 100\"\n\nExample (Equality):\n\n    title: \"Requestor is owner\"\n    description: \"Determines if requestor is the document owner\"\n    expression: \"document.owner == request.auth.claims.email\"\n\nExample (Logic):\n\n    title: \"Public documents\"\n    description: \"Determine whether the document should be publicly visible\"\n    expression: \"document.type != 'private' \u0026\u0026 document.type != 'internal'\"\n\nExample (Data Manipulation):\n\n    title: \"Notification string\"\n    description: \"Create a notification string with a timestamp.\"\n    expression: \"'New message received at ' + string(document.create_time)\"\n\nThe exact variables and functions that may be referenced within an expression\nare determined by the service that evaluates it. See the service\ndocumentation for additional information.",
       "id": "Expr",
       "properties": {
         "description": {
-          "description": "An optional description of the expression. This is a longer text which\ndescribes the expression, e.g. when hovered over it in a UI.",
+          "description": "Optional. Description of the expression. This is a longer text which\ndescribes the expression, e.g. when hovered over it in a UI.",
           "type": "string"
         },
         "expression": {
-          "description": "Textual representation of an expression in\nCommon Expression Language syntax.\n\nThe application context of the containing message determines which\nwell-known feature set of CEL is supported.",
+          "description": "Textual representation of an expression in Common Expression Language\nsyntax.",
           "type": "string"
         },
         "location": {
-          "description": "An optional string indicating the location of the expression for error\nreporting, e.g. a file name and a position in the file.",
+          "description": "Optional. String indicating the location of the expression for error\nreporting, e.g. a file name and a position in the file.",
           "type": "string"
         },
         "title": {
-          "description": "An optional title for the expression, i.e. a short string describing\nits purpose. This can be used e.g. in UIs which allow to enter the\nexpression.",
+          "description": "Optional. Title for the expression, i.e. a short string describing\nits purpose. This can be used e.g. in UIs which allow to enter the\nexpression.",
           "type": "string"
         }
       },
@@ -1013,7 +1020,24 @@
     "GetIamPolicyRequest": {
       "description": "Request message for `GetIamPolicy` method.",
       "id": "GetIamPolicyRequest",
-      "properties": {},
+      "properties": {
+        "options": {
+          "$ref": "GetPolicyOptions",
+          "description": "OPTIONAL: A `GetPolicyOptions` object for specifying options to\n`GetIamPolicy`."
+        }
+      },
+      "type": "object"
+    },
+    "GetPolicyOptions": {
+      "description": "Encapsulates settings provided to GetIamPolicy.",
+      "id": "GetPolicyOptions",
+      "properties": {
+        "requestedPolicyVersion": {
+          "description": "Optional. The policy format version to be returned.\n\nValid values are 0, 1, and 3. Requests specifying an invalid value will be\nrejected.\n\nRequests for policies with any conditional bindings must specify version 3.\nPolicies without any conditional bindings may specify any valid value or\nleave the field unset.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM\ndocumentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
       "type": "object"
     },
     "LeaseTasksRequest": {
@@ -1025,7 +1049,7 @@
           "type": "string"
         },
         "leaseDuration": {
-          "description": "\nAfter the worker has successfully finished the work associated\nwith the task, the worker must call via\nAcknowledgeTask before the\nschedule_time. Otherwise the task will be\nreturned to a later LeaseTasks call so\nthat another worker can retry it.\n\nThe maximum lease duration is 1 week.\n`lease_duration` will be truncated to the nearest second.",
+          "description": "Required. The duration of the lease.\n\nEach task returned in the response will\nhave its schedule_time set to the current\ntime plus the `lease_duration`. The task is leased until its\nschedule_time; thus, the task will not be\nreturned to another LeaseTasks call\nbefore its schedule_time.\n\n\nAfter the worker has successfully finished the work associated\nwith the task, the worker must call via\nAcknowledgeTask before the\nschedule_time. Otherwise the task will be\nreturned to a later LeaseTasks call so\nthat another worker can retry it.\n\nThe maximum lease duration is 1 week.\n`lease_duration` will be truncated to the nearest second.",
           "format": "google-duration",
           "type": "string"
         },
@@ -1160,23 +1184,23 @@
       "type": "object"
     },
     "Policy": {
-      "description": "Defines an Identity and Access Management (IAM) policy. It is used to\nspecify access control policies for Cloud Platform resources.\n\n\nA `Policy` consists of a list of `bindings`. A `binding` binds a list of\n`members` to a `role`, where the members can be user accounts, Google groups,\nGoogle domains, and service accounts. A `role` is a named list of permissions\ndefined by IAM.\n\n**JSON Example**\n\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/owner\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-other-app@appspot.gserviceaccount.com\"\n          ]\n        },\n        {\n          \"role\": \"roles/viewer\",\n          \"members\": [\"user:sean@example.com\"]\n        }\n      ]\n    }\n\n**YAML Example**\n\n    bindings:\n    - members:\n      - user:mike@example.com\n      - group:admins@example.com\n      - domain:google.com\n      - serviceAccount:my-other-app@appspot.gserviceaccount.com\n      role: roles/owner\n    - members:\n      - user:sean@example.com\n      role: roles/viewer\n\n\nFor a description of IAM and its features, see the\n[IAM developer's guide](https://cloud.google.com/iam/docs).",
+      "description": "An Identity and Access Management (IAM) policy, which specifies access\ncontrols for Google Cloud resources.\n\n\nA `Policy` is a collection of `bindings`. A `binding` binds one or more\n`members` to a single `role`. Members can be user accounts, service accounts,\nGoogle groups, and domains (such as G Suite). A `role` is a named list of\npermissions; each `role` can be an IAM predefined role or a user-created\ncustom role.\n\nFor some types of Google Cloud resources, a `binding` can also specify a\n`condition`, which is a logical expression that allows access to a resource\nonly if the expression evaluates to `true`. A condition can add constraints\nbased on attributes of the request, the resource, or both. To learn which\nresources support conditions in their IAM policies, see the\n[IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).\n\n**JSON example:**\n\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/resourcemanager.organizationAdmin\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-project-id@appspot.gserviceaccount.com\"\n          ]\n        },\n        {\n          \"role\": \"roles/resourcemanager.organizationViewer\",\n          \"members\": [\n            \"user:eve@example.com\"\n          ],\n          \"condition\": {\n            \"title\": \"expirable access\",\n            \"description\": \"Does not grant access after Sep 2020\",\n            \"expression\": \"request.time \u003c timestamp('2020-10-01T00:00:00.000Z')\",\n          }\n        }\n      ],\n      \"etag\": \"BwWWja0YfJA=\",\n      \"version\": 3\n    }\n\n**YAML example:**\n\n    bindings:\n    - members:\n      - user:mike@example.com\n      - group:admins@example.com\n      - domain:google.com\n      - serviceAccount:my-project-id@appspot.gserviceaccount.com\n      role: roles/resourcemanager.organizationAdmin\n    - members:\n      - user:eve@example.com\n      role: roles/resourcemanager.organizationViewer\n      condition:\n        title: expirable access\n        description: Does not grant access after Sep 2020\n        expression: request.time \u003c timestamp('2020-10-01T00:00:00.000Z')\n    - etag: BwWWja0YfJA=\n    - version: 3\n\nFor a description of IAM and its features, see the\n[IAM documentation](https://cloud.google.com/iam/docs/).",
       "id": "Policy",
       "properties": {
         "bindings": {
-          "description": "Associates a list of `members` to a `role`.\n`bindings` with no members will result in an error.",
+          "description": "Associates a list of `members` to a `role`. Optionally, may specify a\n`condition` that determines how and when the `bindings` are applied. Each\nof the `bindings` must contain at least one member.",
           "items": {
             "$ref": "Binding"
           },
           "type": "array"
         },
         "etag": {
-          "description": "`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\nIf no `etag` is provided in the call to `setIamPolicy`, then the existing\npolicy is overwritten blindly.",
+          "description": "`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\n**Important:** If you use IAM Conditions, you must include the `etag` field\nwhenever you call `setIamPolicy`. If you omit this field, then IAM allows\nyou to overwrite a version `3` policy with a version `1` policy, and all of\nthe conditions in the version `3` policy are lost.",
           "format": "byte",
           "type": "string"
         },
         "version": {
-          "description": "Deprecated.",
+          "description": "Specifies the format of the policy.\n\nValid values are `0`, `1`, and `3`. Requests that specify an invalid value\nare rejected.\n\nAny operation that affects conditional role bindings must specify version\n`3`. This requirement applies to the following operations:\n\n* Getting a policy that includes a conditional role binding\n* Adding a conditional role binding to a policy\n* Changing a conditional role binding in a policy\n* Removing any role binding, with or without a condition, from a policy\n  that includes conditions\n\n**Important:** If you use IAM Conditions, you must include the `etag` field\nwhenever you call `setIamPolicy`. If you omit this field, then IAM allows\nyou to overwrite a version `3` policy with a version `1` policy, and all of\nthe conditions in the version `3` policy are lost.\n\nIf a policy does not include any conditions, operations on that policy may\nspecify any valid version or leave the field unset.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
           "format": "int32",
           "type": "integer"
         }
@@ -1286,7 +1310,7 @@
       "id": "RenewLeaseRequest",
       "properties": {
         "leaseDuration": {
-          "description": "Required.\n\nThe desired new lease duration, starting from now.\n\n\nThe maximum lease duration is 1 week.\n`lease_duration` will be truncated to the nearest second.",
+          "description": "Required. The desired new lease duration, starting from now.\n\n\nThe maximum lease duration is 1 week.\n`lease_duration` will be truncated to the nearest second.",
           "format": "google-duration",
           "type": "string"
         },
@@ -1305,7 +1329,7 @@
           "type": "string"
         },
         "scheduleTime": {
-          "description": "Required.\n\nThe task's current schedule time, available in the\nschedule_time returned by\nLeaseTasks response or\nRenewLease response. This restriction is\nto ensure that your worker currently holds the lease.",
+          "description": "Required. The task's current schedule time, available in the\nschedule_time returned by\nLeaseTasks response or\nRenewLease response. This restriction is\nto ensure that your worker currently holds the lease.",
           "format": "google-datetime",
           "type": "string"
         }
@@ -1333,7 +1357,7 @@
           "type": "string"
         },
         "maxDoublings": {
-          "description": "The time between retries will double `max_doublings` times.\n\nA task's retry interval starts at\nmin_backoff, then doubles\n`max_doublings` times, then increases linearly, and finally\nretries retries at intervals of\nmax_backoff up to\nmax_attempts times.\n\nFor example, if min_backoff is 10s,\nmax_backoff is 300s, and\n`max_doublings` is 3, then the a task will first be retried in\n10s. The retry interval will double three times, and then\nincrease linearly by 2^3 * 10s.  Finally, the task will retry at\nintervals of max_backoff until the\ntask has been attempted max_attempts\ntimes. Thus, the requests will retry at 10s, 20s, 40s, 80s, 160s,\n240s, 300s, 300s, ....\n\nIf unspecified when the queue is created, Cloud Tasks will pick the\ndefault.\n\nThis field is output only for pull queues.\n\n\nThis field has the same meaning as\n[max_doublings in\nqueue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).",
+          "description": "The time between retries will double `max_doublings` times.\n\nA task's retry interval starts at\nmin_backoff, then doubles\n`max_doublings` times, then increases linearly, and finally\nretries at intervals of\nmax_backoff up to\nmax_attempts times.\n\nFor example, if min_backoff is 10s,\nmax_backoff is 300s, and\n`max_doublings` is 3, then the a task will first be retried in\n10s. The retry interval will double three times, and then\nincrease linearly by 2^3 * 10s.  Finally, the task will retry at\nintervals of max_backoff until the\ntask has been attempted max_attempts\ntimes. Thus, the requests will retry at 10s, 20s, 40s, 80s, 160s,\n240s, 300s, 300s, ....\n\nIf unspecified when the queue is created, Cloud Tasks will pick the\ndefault.\n\nThis field is output only for pull queues.\n\n\nThis field has the same meaning as\n[max_doublings in\nqueue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).",
           "format": "int32",
           "type": "integer"
         },
@@ -1387,7 +1411,7 @@
       "type": "object"
     },
     "Status": {
-      "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). The error model is designed to be:\n\n- Simple to use and understand for most users\n- Flexible enough to meet unexpected needs\n\n# Overview\n\nThe `Status` message contains three pieces of data: error code, error\nmessage, and error details. The error code should be an enum value of\ngoogle.rpc.Code, but it may accept additional error codes if needed.  The\nerror message should be a developer-facing English message that helps\ndevelopers *understand* and *resolve* the error. If a localized user-facing\nerror message is needed, put the localized message in the error details or\nlocalize it in the client. The optional error details may contain arbitrary\ninformation about the error. There is a predefined set of error detail types\nin the package `google.rpc` that can be used for common error conditions.\n\n# Language mapping\n\nThe `Status` message is the logical representation of the error model, but it\nis not necessarily the actual wire format. When the `Status` message is\nexposed in different client libraries and different wire protocols, it can be\nmapped differently. For example, it will likely be mapped to some exceptions\nin Java, but more likely mapped to some error codes in C.\n\n# Other uses\n\nThe error model and the `Status` message can be used in a variety of\nenvironments, either with or without APIs, to provide a\nconsistent developer experience across different environments.\n\nExample uses of this error model include:\n\n- Partial errors. If a service needs to return partial errors to the client,\n    it may embed the `Status` in the normal response to indicate the partial\n    errors.\n\n- Workflow errors. A typical workflow has multiple steps. Each step may\n    have a `Status` message for error reporting.\n\n- Batch operations. If a client uses batch request and batch response, the\n    `Status` message should be used directly inside batch response, one for\n    each error sub-response.\n\n- Asynchronous operations. If an API call embeds asynchronous operation\n    results in its response, the status of those operations should be\n    represented directly using the `Status` message.\n\n- Logging. If some API errors are stored in logs, the message `Status` could\n    be used directly after any stripping needed for security/privacy reasons.",
+      "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors).",
       "id": "Status",
       "properties": {
         "code": {

--- a/gen/model/cloudtasks/v2beta3/cloudtasks-api.json
+++ b/gen/model/cloudtasks/v2beta3/cloudtasks-api.json
@@ -22,6 +22,7 @@
   },
   "id": "cloudtasks:v2beta3",
   "kind": "discovery#restDescription",
+  "mtlsRootUrl": "https://cloudtasks.mtls.googleapis.com/",
   "name": "cloudtasks",
   "ownerDomain": "google.com",
   "ownerName": "Google",
@@ -188,7 +189,7 @@
                   ],
                   "parameters": {
                     "parent": {
-                      "description": "Required.\n\nThe location name in which the queue will be created.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`\n\nThe list of allowed locations can be obtained by calling Cloud\nTasks' implementation of\nListLocations.",
+                      "description": "Required. The location name in which the queue will be created.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`\n\nThe list of allowed locations can be obtained by calling Cloud\nTasks' implementation of\nListLocations.",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+$",
                       "required": true,
@@ -216,7 +217,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -241,7 +242,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe resource name of the queue. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The resource name of the queue. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -310,7 +311,7 @@
                       "type": "string"
                     },
                     "parent": {
-                      "description": "Required.\n\nThe location name.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`",
+                      "description": "Required. The location name.\nFor example: `projects/PROJECT_ID/locations/LOCATION_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+$",
                       "required": true,
@@ -369,7 +370,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -397,7 +398,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -425,7 +426,7 @@
                   ],
                   "parameters": {
                     "name": {
-                      "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
+                      "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`",
                       "location": "path",
                       "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                       "required": true,
@@ -504,7 +505,7 @@
                 "tasks": {
                   "methods": {
                     "create": {
-                      "description": "Creates a task and adds it to a queue.\n\nTasks cannot be updated after creation; there is no UpdateTask command.\n\n* For App Engine queues, the maximum task size is\n  100KB.",
+                      "description": "Creates a task and adds it to a queue.\n\nTasks cannot be updated after creation; there is no UpdateTask command.\n\n* The maximum task size is 100KB.",
                       "flatPath": "v2beta3/projects/{projectsId}/locations/{locationsId}/queues/{queuesId}/tasks",
                       "httpMethod": "POST",
                       "id": "cloudtasks.projects.locations.queues.tasks.create",
@@ -513,7 +514,7 @@
                       ],
                       "parameters": {
                         "parent": {
-                          "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`\n\nThe queue must already exist.",
+                          "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`\n\nThe queue must already exist.",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                           "required": true,
@@ -541,7 +542,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -566,7 +567,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -601,7 +602,7 @@
                       ],
                       "parameters": {
                         "pageSize": {
-                          "description": "Requested page size. Fewer tasks than requested might be returned.\n\nThe maximum page size is 1000. If unspecified, the page size will\nbe the maximum. Fewer tasks than requested might be returned,\neven if more tasks exist; use\nnext_page_token in the\nresponse to determine if more tasks exist.",
+                          "description": "Maximum page size.\n\nFewer tasks than requested might be returned, even if more tasks exist; use\nnext_page_token in the response to\ndetermine if more tasks exist.\n\nThe maximum page size is 1000. If unspecified, the page size will be the\nmaximum.",
                           "format": "int32",
                           "location": "query",
                           "type": "integer"
@@ -612,7 +613,7 @@
                           "type": "string"
                         },
                         "parent": {
-                          "description": "Required.\n\nThe queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
+                          "description": "Required. The queue name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+$",
                           "required": true,
@@ -647,7 +648,7 @@
                       ],
                       "parameters": {
                         "name": {
-                          "description": "Required.\n\nThe task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
+                          "description": "Required. The task name. For example:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`",
                           "location": "path",
                           "pattern": "^projects/[^/]+/locations/[^/]+/queues/[^/]+/tasks/[^/]+$",
                           "required": true,
@@ -674,7 +675,7 @@
       }
     }
   },
-  "revision": "20190412",
+  "revision": "20200529",
   "rootUrl": "https://cloudtasks.googleapis.com/",
   "schemas": {
     "AppEngineHttpQueue": {
@@ -689,7 +690,7 @@
       "type": "object"
     },
     "AppEngineHttpRequest": {
-      "description": "App Engine HTTP request.\n\nThe message defines the HTTP request that is sent to an App Engine app when\nthe task is dispatched.\n\nThis proto can only be used for tasks in a queue which has\napp_engine_http_queue set.\n\nUsing AppEngineHttpRequest requires\n[`appengine.applications.get`](https://cloud.google.com/appengine/docs/admin-api/access-control)\nGoogle IAM permission for the project\nand the following scope:\n\n`https://www.googleapis.com/auth/cloud-platform`\n\nThe task will be delivered to the App Engine app which belongs to the same\nproject as the queue. For more information, see\n[How Requests are\nRouted](https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed)\nand how routing is affected by\n[dispatch\nfiles](https://cloud.google.com/appengine/docs/python/config/dispatchref).\nTraffic is encrypted during transport and never leaves Google datacenters.\nBecause this traffic is carried over a communication mechanism internal to\nGoogle, you cannot explicitly set the protocol (for example, HTTP or HTTPS).\nThe request to the handler, however, will appear to have used the HTTP\nprotocol.\n\nThe AppEngineRouting used to construct the URL that the task is\ndelivered to can be set at the queue-level or task-level:\n\n* If set,\n   app_engine_routing_override\n   is used for all tasks in the queue, no matter what the setting\n   is for the\n   task-level app_engine_routing.\n\n\nThe `url` that the task will be sent to is:\n\n* `url =` host `+`\n  relative_uri\n\nTasks can be dispatched to secure app handlers, unsecure app handlers, and\nURIs restricted with\n[`login:\nadmin`](https://cloud.google.com/appengine/docs/standard/python/config/appref).\nBecause tasks are not run as any user, they cannot be dispatched to URIs\nrestricted with\n[`login:\nrequired`](https://cloud.google.com/appengine/docs/standard/python/config/appref)\nTask dispatches also do not follow redirects.\n\nThe task attempt has succeeded if the app's request handler returns\nan HTTP response code in the range [`200` - `299`]. `503` is\nconsidered an App Engine system error instead of an application\nerror. Requests returning error `503` will be retried regardless of\nretry configuration and not counted against retry counts.\nAny other response code or a failure to receive a response before the\ndeadline is a failed attempt.",
+      "description": "App Engine HTTP request.\n\nThe message defines the HTTP request that is sent to an App Engine app when\nthe task is dispatched.\n\nUsing AppEngineHttpRequest requires\n[`appengine.applications.get`](https://cloud.google.com/appengine/docs/admin-api/access-control)\nGoogle IAM permission for the project\nand the following scope:\n\n`https://www.googleapis.com/auth/cloud-platform`\n\nThe task will be delivered to the App Engine app which belongs to the same\nproject as the queue. For more information, see\n[How Requests are\nRouted](https://cloud.google.com/appengine/docs/standard/python/how-requests-are-routed)\nand how routing is affected by\n[dispatch\nfiles](https://cloud.google.com/appengine/docs/python/config/dispatchref).\nTraffic is encrypted during transport and never leaves Google datacenters.\nBecause this traffic is carried over a communication mechanism internal to\nGoogle, you cannot explicitly set the protocol (for example, HTTP or HTTPS).\nThe request to the handler, however, will appear to have used the HTTP\nprotocol.\n\nThe AppEngineRouting used to construct the URL that the task is\ndelivered to can be set at the queue-level or task-level:\n\n* If set,\n  app_engine_routing_override\n  is used for all tasks in the queue, no matter what the setting\n  is for the\n  task-level app_engine_routing.\n\n\nThe `url` that the task will be sent to is:\n\n* `url =` host `+`\n  relative_uri\n\nTasks can be dispatched to secure app handlers, unsecure app handlers, and\nURIs restricted with\n[`login:\nadmin`](https://cloud.google.com/appengine/docs/standard/python/config/appref).\nBecause tasks are not run as any user, they cannot be dispatched to URIs\nrestricted with\n[`login:\nrequired`](https://cloud.google.com/appengine/docs/standard/python/config/appref)\nTask dispatches also do not follow redirects.\n\nThe task attempt has succeeded if the app's request handler returns an HTTP\nresponse code in the range [`200` - `299`]. The task attempt has failed if\nthe app's handler returns a non-2xx response code or Cloud Tasks does\nnot receive response before the deadline. Failed\ntasks will be retried according to the\nretry configuration. `503` (Service Unavailable) is\nconsidered an App Engine system error instead of an application error and\nwill cause Cloud Tasks' traffic congestion control to temporarily throttle\nthe queue's dispatches. Unlike other types of task targets, a `429` (Too Many\nRequests) response from an app handler does not cause traffic congestion\ncontrol to throttle the queue.",
       "id": "AppEngineHttpRequest",
       "properties": {
         "appEngineRouting": {
@@ -705,11 +706,11 @@
           "additionalProperties": {
             "type": "string"
           },
-          "description": "HTTP request headers.\n\nThis map contains the header field names and values.\nHeaders can be set when the\ntask is created.\nRepeated headers are not supported but a header value can contain commas.\n\nCloud Tasks sets some headers to default values:\n\n* `User-Agent`: By default, this header is\n  `\"AppEngine-Google; (+http://code.google.com/appengine)\"`.\n  This header can be modified, but Cloud Tasks will append\n  `\"AppEngine-Google; (+http://code.google.com/appengine)\"` to the\n  modified `User-Agent`.\n\nIf the task has a body, Cloud\nTasks sets the following headers:\n\n* `Content-Type`: By default, the `Content-Type` header is set to\n  `\"application/octet-stream\"`. The default can be overridden by explicitly\n  setting `Content-Type` to a particular media type when the\n  task is created.\n  For example, `Content-Type` can be set to `\"application/json\"`.\n* `Content-Length`: This is computed by Cloud Tasks. This value is\n  output only.   It cannot be changed.\n\nThe headers below cannot be set or overridden:\n\n* `Host`\n* `X-Google-*`\n* `X-AppEngine-*`\n\nIn addition, Cloud Tasks sets some headers when the task is dispatched,\nsuch as headers containing information about the task; see\n[request\nheaders](https://cloud.google.com/appengine/docs/python/taskqueue/push/creating-handlers#reading_request_headers).\nThese headers are set only when the task is dispatched, so they are not\nvisible when the task is returned in a Cloud Tasks response.\n\nAlthough there is no specific limit for the maximum number of headers or\nthe size, there is a limit on the maximum size of the Task. For more\ninformation, see the CreateTask documentation.",
+          "description": "HTTP request headers.\n\nThis map contains the header field names and values.\nHeaders can be set when the\ntask is created.\nRepeated headers are not supported but a header value can contain commas.\n\nCloud Tasks sets some headers to default values:\n\n* `User-Agent`: By default, this header is\n  `\"AppEngine-Google; (+http://code.google.com/appengine)\"`.\n  This header can be modified, but Cloud Tasks will append\n  `\"AppEngine-Google; (+http://code.google.com/appengine)\"` to the\n  modified `User-Agent`.\n\nIf the task has a body, Cloud\nTasks sets the following headers:\n\n* `Content-Type`: By default, the `Content-Type` header is set to\n  `\"application/octet-stream\"`. The default can be overridden by explicitly\n  setting `Content-Type` to a particular media type when the\n  task is created.\n  For example, `Content-Type` can be set to `\"application/json\"`.\n* `Content-Length`: This is computed by Cloud Tasks. This value is\n  output only.   It cannot be changed.\n\nThe headers below cannot be set or overridden:\n\n* `Host`\n* `X-Google-*`\n* `X-AppEngine-*`\n\nIn addition, Cloud Tasks sets some headers when the task is dispatched,\nsuch as headers containing information about the task; see\n[request\nheaders](https://cloud.google.com/tasks/docs/creating-appengine-handlers#reading_request_headers).\nThese headers are set only when the task is dispatched, so they are not\nvisible when the task is returned in a Cloud Tasks response.\n\nAlthough there is no specific limit for the maximum number of headers or\nthe size, there is a limit on the maximum size of the Task. For more\ninformation, see the CreateTask documentation.",
           "type": "object"
         },
         "httpMethod": {
-          "description": "The HTTP method to use for the request. The default is POST.\n\nThe app's request handler for the task's target URL must be able to handle\nHTTP requests with this http_method, otherwise the task attempt will fail\nwith error code 405 (Method Not Allowed). See\n[Writing a push task request\nhandler](https://cloud.google.com/appengine/docs/java/taskqueue/push/creating-handlers#writing_a_push_task_request_handler)\nand the documentation for the request handlers in the language your app is\nwritten in e.g.\n[Python Request\nHandler](https://cloud.google.com/appengine/docs/python/tools/webapp/requesthandlerclass).",
+          "description": "The HTTP method to use for the request. The default is POST.\n\nThe app's request handler for the task's target URL must be able to handle\nHTTP requests with this http_method, otherwise the task attempt fails with\nerror code 405 (Method Not Allowed). See [Writing a push task request\nhandler](https://cloud.google.com/appengine/docs/java/taskqueue/push/creating-handlers#writing_a_push_task_request_handler)\nand the App Engine documentation for your runtime on [How Requests are\nHandled](https://cloud.google.com/appengine/docs/standard/python3/how-requests-are-handled).",
           "enum": [
             "HTTP_METHOD_UNSPECIFIED",
             "POST",
@@ -794,10 +795,10 @@
       "properties": {
         "condition": {
           "$ref": "Expr",
-          "description": "The condition that is associated with this binding.\nNOTE: An unsatisfied condition will not allow user access via current\nbinding. Different bindings, including their conditions, are examined\nindependently."
+          "description": "The condition that is associated with this binding.\n\nIf the condition evaluates to `true`, then this binding applies to the\ncurrent request.\n\nIf the condition evaluates to `false`, then this binding does not apply to\nthe current request. However, a different role binding might grant the same\nrole to one or more of the members in this binding.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM\ndocumentation](https://cloud.google.com/iam/help/conditions/resource-policies)."
         },
         "members": {
-          "description": "Specifies the identities requesting access for a Cloud Platform resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@gmail.com` .\n\n\n* `serviceAccount:{emailid}`: An email address that represents a service\n   account. For example, `my-other-app@appspot.gserviceaccount.com`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n\n* `domain:{domain}`: The G Suite domain (primary) that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n",
+          "description": "Specifies the identities requesting access for a Cloud Platform resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@example.com` .\n\n\n* `serviceAccount:{emailid}`: An email address that represents a service\n   account. For example, `my-other-app@appspot.gserviceaccount.com`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n* `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique\n   identifier) representing a user that has been recently deleted. For\n   example, `alice@example.com?uid=123456789012345678901`. If the user is\n   recovered, this value reverts to `user:{emailid}` and the recovered user\n   retains the role in the binding.\n\n* `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus\n   unique identifier) representing a service account that has been recently\n   deleted. For example,\n   `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`.\n   If the service account is undeleted, this value reverts to\n   `serviceAccount:{emailid}` and the undeleted service account retains the\n   role in the binding.\n\n* `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique\n   identifier) representing a Google group that has been recently\n   deleted. For example, `admins@example.com?uid=123456789012345678901`. If\n   the group is recovered, this value reverts to `group:{emailid}` and the\n   recovered group retains the role in the binding.\n\n\n* `domain:{domain}`: The G Suite domain (primary) that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n",
           "items": {
             "type": "string"
           },
@@ -830,7 +831,7 @@
         },
         "task": {
           "$ref": "Task",
-          "description": "Required.\n\nThe task to add.\n\nTask names have the following format:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.\nThe user can optionally specify a task name. If a\nname is not specified then the system will generate a random\nunique task id, which will be set in the task returned in the\nresponse.\n\nIf schedule_time is not set or is in the\npast then Cloud Tasks will set it to the current time.\n\nTask De-duplication:\n\nExplicitly specifying a task ID enables task de-duplication.  If\na task's ID is identical to that of an existing task or a task\nthat was deleted or executed recently then the call will fail\nwith ALREADY_EXISTS.\nIf the task's queue was created using Cloud Tasks, then another task with\nthe same name can't be created for ~1hour after the original task was\ndeleted or executed. If the task's queue was created using queue.yaml or\nqueue.xml, then another task with the same name can't be created\nfor ~9days after the original task was deleted or executed.\n\nBecause there is an extra lookup cost to identify duplicate task\nnames, these CreateTask calls have significantly\nincreased latency. Using hashed strings for the task id or for\nthe prefix of the task id is recommended. Choosing task ids that\nare sequential or have sequential prefixes, for example using a\ntimestamp, causes an increase in latency and error rates in all\ntask commands. The infrastructure relies on an approximately\nuniform distribution of task ids to store and serve tasks\nefficiently."
+          "description": "Required. The task to add.\n\nTask names have the following format:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`.\nThe user can optionally specify a task name. If a\nname is not specified then the system will generate a random\nunique task id, which will be set in the task returned in the\nresponse.\n\nIf schedule_time is not set or is in the\npast then Cloud Tasks will set it to the current time.\n\nTask De-duplication:\n\nExplicitly specifying a task ID enables task de-duplication.  If\na task's ID is identical to that of an existing task or a task\nthat was deleted or executed recently then the call will fail\nwith ALREADY_EXISTS.\nIf the task's queue was created using Cloud Tasks, then another task with\nthe same name can't be created for ~1hour after the original task was\ndeleted or executed. If the task's queue was created using queue.yaml or\nqueue.xml, then another task with the same name can't be created\nfor ~9days after the original task was deleted or executed.\n\nBecause there is an extra lookup cost to identify duplicate task\nnames, these CreateTask calls have significantly\nincreased latency. Using hashed strings for the task id or for\nthe prefix of the task id is recommended. Choosing task ids that\nare sequential or have sequential prefixes, for example using a\ntimestamp, causes an increase in latency and error rates in all\ntask commands. The infrastructure relies on an approximately\nuniform distribution of task ids to store and serve tasks\nefficiently."
         }
       },
       "type": "object"
@@ -842,23 +843,23 @@
       "type": "object"
     },
     "Expr": {
-      "description": "Represents an expression text. Example:\n\n    title: \"User account presence\"\n    description: \"Determines whether the request has a user account\"\n    expression: \"size(request.user) \u003e 0\"",
+      "description": "Represents a textual expression in the Common Expression Language (CEL)\nsyntax. CEL is a C-like expression language. The syntax and semantics of CEL\nare documented at https://github.com/google/cel-spec.\n\nExample (Comparison):\n\n    title: \"Summary size limit\"\n    description: \"Determines if a summary is less than 100 chars\"\n    expression: \"document.summary.size() \u003c 100\"\n\nExample (Equality):\n\n    title: \"Requestor is owner\"\n    description: \"Determines if requestor is the document owner\"\n    expression: \"document.owner == request.auth.claims.email\"\n\nExample (Logic):\n\n    title: \"Public documents\"\n    description: \"Determine whether the document should be publicly visible\"\n    expression: \"document.type != 'private' \u0026\u0026 document.type != 'internal'\"\n\nExample (Data Manipulation):\n\n    title: \"Notification string\"\n    description: \"Create a notification string with a timestamp.\"\n    expression: \"'New message received at ' + string(document.create_time)\"\n\nThe exact variables and functions that may be referenced within an expression\nare determined by the service that evaluates it. See the service\ndocumentation for additional information.",
       "id": "Expr",
       "properties": {
         "description": {
-          "description": "An optional description of the expression. This is a longer text which\ndescribes the expression, e.g. when hovered over it in a UI.",
+          "description": "Optional. Description of the expression. This is a longer text which\ndescribes the expression, e.g. when hovered over it in a UI.",
           "type": "string"
         },
         "expression": {
-          "description": "Textual representation of an expression in\nCommon Expression Language syntax.\n\nThe application context of the containing message determines which\nwell-known feature set of CEL is supported.",
+          "description": "Textual representation of an expression in Common Expression Language\nsyntax.",
           "type": "string"
         },
         "location": {
-          "description": "An optional string indicating the location of the expression for error\nreporting, e.g. a file name and a position in the file.",
+          "description": "Optional. String indicating the location of the expression for error\nreporting, e.g. a file name and a position in the file.",
           "type": "string"
         },
         "title": {
-          "description": "An optional title for the expression, i.e. a short string describing\nits purpose. This can be used e.g. in UIs which allow to enter the\nexpression.",
+          "description": "Optional. Title for the expression, i.e. a short string describing\nits purpose. This can be used e.g. in UIs which allow to enter the\nexpression.",
           "type": "string"
         }
       },
@@ -867,7 +868,79 @@
     "GetIamPolicyRequest": {
       "description": "Request message for `GetIamPolicy` method.",
       "id": "GetIamPolicyRequest",
-      "properties": {},
+      "properties": {
+        "options": {
+          "$ref": "GetPolicyOptions",
+          "description": "OPTIONAL: A `GetPolicyOptions` object for specifying options to\n`GetIamPolicy`."
+        }
+      },
+      "type": "object"
+    },
+    "GetPolicyOptions": {
+      "description": "Encapsulates settings provided to GetIamPolicy.",
+      "id": "GetPolicyOptions",
+      "properties": {
+        "requestedPolicyVersion": {
+          "description": "Optional. The policy format version to be returned.\n\nValid values are 0, 1, and 3. Requests specifying an invalid value will be\nrejected.\n\nRequests for policies with any conditional bindings must specify version 3.\nPolicies without any conditional bindings may specify any valid value or\nleave the field unset.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM\ndocumentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "HttpRequest": {
+      "description": "HTTP request.\n\nThe task will be pushed to the worker as an HTTP request. If the worker\nor the redirected worker acknowledges the task by returning a successful HTTP\nresponse code ([`200` - `299`]), the task will be removed from the queue. If\nany other HTTP response code is returned or no response is received, the\ntask will be retried according to the following:\n\n* User-specified throttling: retry configuration,\n  rate limits, and the queue's state.\n\n* System throttling: To prevent the worker from overloading, Cloud Tasks may\n  temporarily reduce the queue's effective rate. User-specified settings\n  will not be changed.\n\n System throttling happens because:\n\n  * Cloud Tasks backs off on all errors. Normally the backoff specified in\n    rate limits will be used. But if the worker returns\n    `429` (Too Many Requests), `503` (Service Unavailable), or the rate of\n    errors is high, Cloud Tasks will use a higher backoff rate. The retry\n    specified in the `Retry-After` HTTP response header is considered.\n\n  * To prevent traffic spikes and to smooth sudden increases in traffic,\n    dispatches ramp up slowly when the queue is newly created or idle and\n    if large numbers of tasks suddenly become available to dispatch (due to\n    spikes in create task rates, the queue being unpaused, or many tasks\n    that are scheduled at the same time).",
+      "id": "HttpRequest",
+      "properties": {
+        "body": {
+          "description": "HTTP request body.\n\nA request body is allowed only if the\nHTTP method is POST, PUT, or PATCH. It is an\nerror to set body on a task with an incompatible HttpMethod.",
+          "format": "byte",
+          "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "HTTP request headers.\n\nThis map contains the header field names and values.\nHeaders can be set when the\ntask is created.\n\nThese headers represent a subset of the headers that will accompany the\ntask's HTTP request. Some HTTP request headers will be ignored or replaced.\n\nA partial list of headers that will be ignored or replaced is:\n\n* Host: This will be computed by Cloud Tasks and derived from\n  HttpRequest.url.\n* Content-Length: This will be computed by Cloud Tasks.\n* User-Agent: This will be set to `\"Google-Cloud-Tasks\"`.\n* X-Google-*: Google use only.\n* X-AppEngine-*: Google use only.\n\n`Content-Type` won't be set by Cloud Tasks. You can explicitly set\n`Content-Type` to a media type when the\n task is created.\n For example, `Content-Type` can be set to `\"application/octet-stream\"` or\n `\"application/json\"`.\n\nHeaders which can have multiple values (according to RFC2616) can be\nspecified using comma-separated values.\n\nThe size of the headers must be less than 80KB.",
+          "type": "object"
+        },
+        "httpMethod": {
+          "description": "The HTTP method to use for the request. The default is POST.",
+          "enum": [
+            "HTTP_METHOD_UNSPECIFIED",
+            "POST",
+            "GET",
+            "HEAD",
+            "PUT",
+            "DELETE",
+            "PATCH",
+            "OPTIONS"
+          ],
+          "enumDescriptions": [
+            "HTTP method unspecified",
+            "HTTP POST",
+            "HTTP GET",
+            "HTTP HEAD",
+            "HTTP PUT",
+            "HTTP DELETE",
+            "HTTP PATCH",
+            "HTTP OPTIONS"
+          ],
+          "type": "string"
+        },
+        "oauthToken": {
+          "$ref": "OAuthToken",
+          "description": "If specified, an\n[OAuth token](https://developers.google.com/identity/protocols/OAuth2)\nwill be generated and attached as an `Authorization` header in the HTTP\nrequest.\n\nThis type of authorization should generally only be used when calling\nGoogle APIs hosted on *.googleapis.com."
+        },
+        "oidcToken": {
+          "$ref": "OidcToken",
+          "description": "If specified, an\n[OIDC](https://developers.google.com/identity/protocols/OpenIDConnect)\ntoken will be generated and attached as an `Authorization` header in the\nHTTP request.\n\nThis type of authorization can be used for many scenarios, including\ncalling Cloud Run, or endpoints where you intend to validate the token\nyourself."
+        },
+        "url": {
+          "description": "Required. The full url path that the request will be sent to.\n\nThis string must begin with either \"http://\" or \"https://\". Some examples\nare: `http://acme.com` and `https://acme.com/sales:8080`. Cloud Tasks will\nencode some characters for safety and compatibility. The maximum allowed\nURL length is 2083 characters after encoding.\n\nThe `Location` header response from a redirect response [`300` - `399`]\nmay be followed. The redirect is not counted as a separate attempt.",
+          "type": "string"
+        }
+      },
       "type": "object"
     },
     "ListLocationsResponse": {
@@ -958,6 +1031,36 @@
       },
       "type": "object"
     },
+    "OAuthToken": {
+      "description": "Contains information needed for generating an\n[OAuth token](https://developers.google.com/identity/protocols/OAuth2).\nThis type of authorization should generally only be used when calling Google\nAPIs hosted on *.googleapis.com.",
+      "id": "OAuthToken",
+      "properties": {
+        "scope": {
+          "description": "OAuth scope to be used for generating OAuth access token.\nIf not specified, \"https://www.googleapis.com/auth/cloud-platform\"\nwill be used.",
+          "type": "string"
+        },
+        "serviceAccountEmail": {
+          "description": "[Service account email](https://cloud.google.com/iam/docs/service-accounts)\nto be used for generating OAuth token.\nThe service account must be within the same project as the queue. The\ncaller must have iam.serviceAccounts.actAs permission for the service\naccount.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "OidcToken": {
+      "description": "Contains information needed for generating an\n[OpenID Connect\ntoken](https://developers.google.com/identity/protocols/OpenIDConnect).\nThis type of authorization can be used for many scenarios, including\ncalling Cloud Run, or endpoints where you intend to validate the token\nyourself.",
+      "id": "OidcToken",
+      "properties": {
+        "audience": {
+          "description": "Audience to be used when generating OIDC token. If not specified, the URI\nspecified in target will be used.",
+          "type": "string"
+        },
+        "serviceAccountEmail": {
+          "description": "[Service account email](https://cloud.google.com/iam/docs/service-accounts)\nto be used for generating OIDC token.\nThe service account must be within the same project as the queue. The\ncaller must have iam.serviceAccounts.actAs permission for the service\naccount.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "PauseQueueRequest": {
       "description": "Request message for PauseQueue.",
       "id": "PauseQueueRequest",
@@ -965,23 +1068,23 @@
       "type": "object"
     },
     "Policy": {
-      "description": "Defines an Identity and Access Management (IAM) policy. It is used to\nspecify access control policies for Cloud Platform resources.\n\n\nA `Policy` consists of a list of `bindings`. A `binding` binds a list of\n`members` to a `role`, where the members can be user accounts, Google groups,\nGoogle domains, and service accounts. A `role` is a named list of permissions\ndefined by IAM.\n\n**JSON Example**\n\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/owner\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-other-app@appspot.gserviceaccount.com\"\n          ]\n        },\n        {\n          \"role\": \"roles/viewer\",\n          \"members\": [\"user:sean@example.com\"]\n        }\n      ]\n    }\n\n**YAML Example**\n\n    bindings:\n    - members:\n      - user:mike@example.com\n      - group:admins@example.com\n      - domain:google.com\n      - serviceAccount:my-other-app@appspot.gserviceaccount.com\n      role: roles/owner\n    - members:\n      - user:sean@example.com\n      role: roles/viewer\n\n\nFor a description of IAM and its features, see the\n[IAM developer's guide](https://cloud.google.com/iam/docs).",
+      "description": "An Identity and Access Management (IAM) policy, which specifies access\ncontrols for Google Cloud resources.\n\n\nA `Policy` is a collection of `bindings`. A `binding` binds one or more\n`members` to a single `role`. Members can be user accounts, service accounts,\nGoogle groups, and domains (such as G Suite). A `role` is a named list of\npermissions; each `role` can be an IAM predefined role or a user-created\ncustom role.\n\nFor some types of Google Cloud resources, a `binding` can also specify a\n`condition`, which is a logical expression that allows access to a resource\nonly if the expression evaluates to `true`. A condition can add constraints\nbased on attributes of the request, the resource, or both. To learn which\nresources support conditions in their IAM policies, see the\n[IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).\n\n**JSON example:**\n\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/resourcemanager.organizationAdmin\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-project-id@appspot.gserviceaccount.com\"\n          ]\n        },\n        {\n          \"role\": \"roles/resourcemanager.organizationViewer\",\n          \"members\": [\n            \"user:eve@example.com\"\n          ],\n          \"condition\": {\n            \"title\": \"expirable access\",\n            \"description\": \"Does not grant access after Sep 2020\",\n            \"expression\": \"request.time \u003c timestamp('2020-10-01T00:00:00.000Z')\",\n          }\n        }\n      ],\n      \"etag\": \"BwWWja0YfJA=\",\n      \"version\": 3\n    }\n\n**YAML example:**\n\n    bindings:\n    - members:\n      - user:mike@example.com\n      - group:admins@example.com\n      - domain:google.com\n      - serviceAccount:my-project-id@appspot.gserviceaccount.com\n      role: roles/resourcemanager.organizationAdmin\n    - members:\n      - user:eve@example.com\n      role: roles/resourcemanager.organizationViewer\n      condition:\n        title: expirable access\n        description: Does not grant access after Sep 2020\n        expression: request.time \u003c timestamp('2020-10-01T00:00:00.000Z')\n    - etag: BwWWja0YfJA=\n    - version: 3\n\nFor a description of IAM and its features, see the\n[IAM documentation](https://cloud.google.com/iam/docs/).",
       "id": "Policy",
       "properties": {
         "bindings": {
-          "description": "Associates a list of `members` to a `role`.\n`bindings` with no members will result in an error.",
+          "description": "Associates a list of `members` to a `role`. Optionally, may specify a\n`condition` that determines how and when the `bindings` are applied. Each\nof the `bindings` must contain at least one member.",
           "items": {
             "$ref": "Binding"
           },
           "type": "array"
         },
         "etag": {
-          "description": "`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\nIf no `etag` is provided in the call to `setIamPolicy`, then the existing\npolicy is overwritten blindly.",
+          "description": "`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\n**Important:** If you use IAM Conditions, you must include the `etag` field\nwhenever you call `setIamPolicy`. If you omit this field, then IAM allows\nyou to overwrite a version `3` policy with a version `1` policy, and all of\nthe conditions in the version `3` policy are lost.",
           "format": "byte",
           "type": "string"
         },
         "version": {
-          "description": "Deprecated.",
+          "description": "Specifies the format of the policy.\n\nValid values are `0`, `1`, and `3`. Requests that specify an invalid value\nare rejected.\n\nAny operation that affects conditional role bindings must specify version\n`3`. This requirement applies to the following operations:\n\n* Getting a policy that includes a conditional role binding\n* Adding a conditional role binding to a policy\n* Changing a conditional role binding in a policy\n* Removing any role binding, with or without a condition, from a policy\n  that includes conditions\n\n**Important:** If you use IAM Conditions, you must include the `etag` field\nwhenever you call `setIamPolicy`. If you omit this field, then IAM allows\nyou to overwrite a version `3` policy with a version `1` policy, and all of\nthe conditions in the version `3` policy are lost.\n\nIf a policy does not include any conditions, operations on that policy may\nspecify any valid version or leave the field unset.\n\nTo learn which resources support conditions in their IAM policies, see the\n[IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).",
           "format": "int32",
           "type": "integer"
         }
@@ -1000,7 +1103,7 @@
       "properties": {
         "appEngineHttpQueue": {
           "$ref": "AppEngineHttpQueue",
-          "description": "AppEngineHttpQueue settings apply only to\nApp Engine tasks in this queue."
+          "description": "AppEngineHttpQueue settings apply only to\nApp Engine tasks in this queue.\nHttp tasks are not affected by this proto."
         },
         "name": {
           "description": "Caller-specified and required in CreateQueue,\nafter which it becomes output only.\n\nThe queue name.\n\nThe queue name must have the following format:\n`projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`\n\n* `PROJECT_ID` can contain letters ([A-Za-z]), numbers ([0-9]),\n   hyphens (-), colons (:), or periods (.).\n   For more information, see\n   [Identifying\n   projects](https://cloud.google.com/resource-manager/docs/creating-managing-projects#identifying_projects)\n* `LOCATION_ID` is the canonical ID for the queue's location.\n   The list of available locations can be obtained by calling\n   ListLocations.\n   For more information, see https://cloud.google.com/about/locations/.\n* `QUEUE_ID` can contain letters ([A-Za-z]), numbers ([0-9]), or\n  hyphens (-). The maximum length is 100 characters.",
@@ -1019,6 +1122,10 @@
           "$ref": "RetryConfig",
           "description": "Settings that determine the retry behavior.\n\n* For tasks created using Cloud Tasks: the queue-level retry settings\n  apply to all tasks in the queue that were created using Cloud Tasks.\n  Retry settings cannot be set on individual tasks.\n* For tasks created using the App Engine SDK: the queue-level retry\n  settings apply to all tasks in the queue which do not have retry settings\n  explicitly set on the task and were created by the App Engine SDK. See\n  [App Engine\n  documentation](https://cloud.google.com/appengine/docs/standard/python/taskqueue/push/retrying-tasks)."
         },
+        "stackdriverLoggingConfig": {
+          "$ref": "StackdriverLoggingConfig",
+          "description": "Configuration options for writing logs to\n[Stackdriver Logging](https://cloud.google.com/logging/docs/). If this\nfield is unset, then no logs are written."
+        },
         "state": {
           "description": "Output only. The state of the queue.\n\n`state` can only be changed by called\nPauseQueue,\nResumeQueue, or uploading\n[queue.yaml/xml](https://cloud.google.com/appengine/docs/python/config/queueref).\nUpdateQueue cannot be used to change `state`.",
           "enum": [
@@ -1032,6 +1139,20 @@
             "The queue is running. Tasks can be dispatched.\n\nIf the queue was created using Cloud Tasks and the queue has\nhad no activity (method calls or task dispatches) for 30 days,\nthe queue may take a few minutes to re-activate. Some method\ncalls may return NOT_FOUND and\ntasks may not be dispatched for a few minutes until the queue\nhas been re-activated.",
             "Tasks are paused by the user. If the queue is paused then Cloud\nTasks will stop delivering tasks from it, but more tasks can\nstill be added to it by the user.",
             "The queue is disabled.\n\nA queue becomes `DISABLED` when\n[queue.yaml](https://cloud.google.com/appengine/docs/python/config/queueref)\nor\n[queue.xml](https://cloud.google.com/appengine/docs/standard/java/config/queueref)\nis uploaded which does not contain the queue. You cannot directly disable\na queue.\n\nWhen a queue is disabled, tasks can still be added to a queue\nbut the tasks are not dispatched.\n\nTo permanently delete this queue and all of its tasks, call\nDeleteQueue."
+          ],
+          "type": "string"
+        },
+        "type": {
+          "description": "Immutable. The type of a queue (push or pull).\n\n`Queue.type` is an immutable property of the queue that is set at the queue\ncreation time. When left unspecified, the default value of `PUSH` is\nselected.",
+          "enum": [
+            "TYPE_UNSPECIFIED",
+            "PULL",
+            "PUSH"
+          ],
+          "enumDescriptions": [
+            "Default value.",
+            "A pull queue.",
+            "A push queue."
           ],
           "type": "string"
         }
@@ -1081,7 +1202,7 @@
           "type": "string"
         },
         "maxDoublings": {
-          "description": "The time between retries will double `max_doublings` times.\n\nA task's retry interval starts at\nmin_backoff, then doubles\n`max_doublings` times, then increases linearly, and finally\nretries retries at intervals of\nmax_backoff up to\nmax_attempts times.\n\nFor example, if min_backoff is 10s,\nmax_backoff is 300s, and\n`max_doublings` is 3, then the a task will first be retried in\n10s. The retry interval will double three times, and then\nincrease linearly by 2^3 * 10s.  Finally, the task will retry at\nintervals of max_backoff until the\ntask has been attempted max_attempts\ntimes. Thus, the requests will retry at 10s, 20s, 40s, 80s, 160s,\n240s, 300s, 300s, ....\n\nIf unspecified when the queue is created, Cloud Tasks will pick the\ndefault.\n\n\nThis field has the same meaning as\n[max_doublings in\nqueue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).",
+          "description": "The time between retries will double `max_doublings` times.\n\nA task's retry interval starts at\nmin_backoff, then doubles\n`max_doublings` times, then increases linearly, and finally\nretries at intervals of\nmax_backoff up to\nmax_attempts times.\n\nFor example, if min_backoff is 10s,\nmax_backoff is 300s, and\n`max_doublings` is 3, then the a task will first be retried in\n10s. The retry interval will double three times, and then\nincrease linearly by 2^3 * 10s.  Finally, the task will retry at\nintervals of max_backoff until the\ntask has been attempted max_attempts\ntimes. Thus, the requests will retry at 10s, 20s, 40s, 80s, 160s,\n240s, 300s, 300s, ....\n\nIf unspecified when the queue is created, Cloud Tasks will pick the\ndefault.\n\n\nThis field has the same meaning as\n[max_doublings in\nqueue.yaml/xml](https://cloud.google.com/appengine/docs/standard/python/config/queueref#retry_parameters).",
           "format": "int32",
           "type": "integer"
         },
@@ -1130,8 +1251,20 @@
       },
       "type": "object"
     },
+    "StackdriverLoggingConfig": {
+      "description": "Configuration options for writing logs to\n[Stackdriver Logging](https://cloud.google.com/logging/docs/).",
+      "id": "StackdriverLoggingConfig",
+      "properties": {
+        "samplingRatio": {
+          "description": "Specifies the fraction of operations to write to\n[Stackdriver Logging](https://cloud.google.com/logging/docs/).\nThis field may contain any value between 0.0 and 1.0, inclusive.\n0.0 is the default and means that no operations are logged.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
     "Status": {
-      "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). The error model is designed to be:\n\n- Simple to use and understand for most users\n- Flexible enough to meet unexpected needs\n\n# Overview\n\nThe `Status` message contains three pieces of data: error code, error\nmessage, and error details. The error code should be an enum value of\ngoogle.rpc.Code, but it may accept additional error codes if needed.  The\nerror message should be a developer-facing English message that helps\ndevelopers *understand* and *resolve* the error. If a localized user-facing\nerror message is needed, put the localized message in the error details or\nlocalize it in the client. The optional error details may contain arbitrary\ninformation about the error. There is a predefined set of error detail types\nin the package `google.rpc` that can be used for common error conditions.\n\n# Language mapping\n\nThe `Status` message is the logical representation of the error model, but it\nis not necessarily the actual wire format. When the `Status` message is\nexposed in different client libraries and different wire protocols, it can be\nmapped differently. For example, it will likely be mapped to some exceptions\nin Java, but more likely mapped to some error codes in C.\n\n# Other uses\n\nThe error model and the `Status` message can be used in a variety of\nenvironments, either with or without APIs, to provide a\nconsistent developer experience across different environments.\n\nExample uses of this error model include:\n\n- Partial errors. If a service needs to return partial errors to the client,\n    it may embed the `Status` in the normal response to indicate the partial\n    errors.\n\n- Workflow errors. A typical workflow has multiple steps. Each step may\n    have a `Status` message for error reporting.\n\n- Batch operations. If a client uses batch request and batch response, the\n    `Status` message should be used directly inside batch response, one for\n    each error sub-response.\n\n- Asynchronous operations. If an API call embeds asynchronous operation\n    results in its response, the status of those operations should be\n    represented directly using the `Status` message.\n\n- Logging. If some API errors are stored in logs, the message `Status` could\n    be used directly after any stripping needed for security/privacy reasons.",
+      "description": "The `Status` type defines a logical error model that is suitable for\ndifferent programming environments, including REST APIs and RPC APIs. It is\nused by [gRPC](https://github.com/grpc). Each `Status` message contains\nthree pieces of data: error code, error message, and error details.\n\nYou can find out more about this error model and how to work with it in the\n[API Design Guide](https://cloud.google.com/apis/design/errors).",
       "id": "Status",
       "properties": {
         "code": {
@@ -1176,13 +1309,17 @@
           "type": "integer"
         },
         "dispatchDeadline": {
-          "description": "The deadline for requests sent to the worker. If the worker does not\nrespond by this deadline then the request is cancelled and the attempt\nis marked as a `DEADLINE_EXCEEDED` failure. Cloud Tasks will retry the\ntask according to the RetryConfig.\n\nNote that when the request is cancelled, Cloud Tasks will stop listing for\nthe response, but whether the worker stops processing depends on the\nworker. For example, if the worker is stuck, it may not react to cancelled\nrequests.\n\nThe default and maximum values depend on the type of request:\n\n\n* For App Engine tasks, 0 indicates that the\n  request has the default deadline. The default deadline depends on the\n  [scaling\n  type](https://cloud.google.com/appengine/docs/standard/go/how-instances-are-managed#instance_scaling)\n  of the service: 10 minutes for standard apps with automatic scaling, 24\n  hours for standard apps with manual and basic scaling, and 60 minutes for\n  flex apps. If the request deadline is set, it must be in the interval [15\n  seconds, 24 hours 15 seconds]. Regardless of the task's\n  `dispatch_deadline`, the app handler will not run for longer than than\n  the service's timeout. We recommend setting the `dispatch_deadline` to\n  at most a few seconds more than the app handler's timeout. For more\n  information see\n  [Timeouts](https://cloud.google.com/tasks/docs/creating-appengine-handlers#timeouts).\n\n`dispatch_deadline` will be truncated to the nearest millisecond. The\ndeadline is an approximate deadline.",
+          "description": "The deadline for requests sent to the worker. If the worker does not\nrespond by this deadline then the request is cancelled and the attempt\nis marked as a `DEADLINE_EXCEEDED` failure. Cloud Tasks will retry the\ntask according to the RetryConfig.\n\nNote that when the request is cancelled, Cloud Tasks will stop listening\nfor the response, but whether the worker stops processing depends on the\nworker. For example, if the worker is stuck, it may not react to cancelled\nrequests.\n\nThe default and maximum values depend on the type of request:\n\n* For HTTP tasks, the default is 10 minutes. The deadline\n  must be in the interval [15 seconds, 30 minutes].\n\n* For App Engine tasks, 0 indicates that the\n  request has the default deadline. The default deadline depends on the\n  [scaling\n  type](https://cloud.google.com/appengine/docs/standard/go/how-instances-are-managed#instance_scaling)\n  of the service: 10 minutes for standard apps with automatic scaling, 24\n  hours for standard apps with manual and basic scaling, and 60 minutes for\n  flex apps. If the request deadline is set, it must be in the interval [15\n  seconds, 24 hours 15 seconds]. Regardless of the task's\n  `dispatch_deadline`, the app handler will not run for longer than than\n  the service's timeout. We recommend setting the `dispatch_deadline` to\n  at most a few seconds more than the app handler's timeout. For more\n  information see\n  [Timeouts](https://cloud.google.com/tasks/docs/creating-appengine-handlers#timeouts).\n\n`dispatch_deadline` will be truncated to the nearest millisecond. The\ndeadline is an approximate deadline.",
           "format": "google-duration",
           "type": "string"
         },
         "firstAttempt": {
           "$ref": "Attempt",
           "description": "Output only. The status of the task's first attempt.\n\nOnly dispatch_time will be set.\nThe other Attempt information is not retained by Cloud Tasks."
+        },
+        "httpRequest": {
+          "$ref": "HttpRequest",
+          "description": "HTTP request that is sent to the task's target.\n\nAn HTTP task is a task that has HttpRequest set."
         },
         "lastAttempt": {
           "$ref": "Attempt",

--- a/gogol-cloudtasks/gen/Network/Google/CloudTasks.hs
+++ b/gogol-cloudtasks/gen/Network/Google/CloudTasks.hs
@@ -92,6 +92,12 @@ module Network.Google.CloudTasks
     , rlMaxDispatchesPerSecond
     , rlMaxBurstSize
 
+    -- ** OAuthToken
+    , OAuthToken
+    , oAuthToken
+    , oatScope
+    , oatServiceAccountEmail
+
     -- ** Status
     , Status
     , status
@@ -116,6 +122,13 @@ module Network.Google.CloudTasks
     -- ** GetIAMPolicyRequest
     , GetIAMPolicyRequest
     , getIAMPolicyRequest
+    , giprOptions
+
+    -- ** OidcToken
+    , OidcToken
+    , oidcToken
+    , otAudience
+    , otServiceAccountEmail
 
     -- ** RetryConfig
     , RetryConfig
@@ -130,6 +143,11 @@ module Network.Google.CloudTasks
     , RunTaskRequest
     , runTaskRequest
     , rtrResponseView
+
+    -- ** HTTPRequestHeaders
+    , HTTPRequestHeaders
+    , hTTPRequestHeaders
+    , httprhAddtional
 
     -- ** Location
     , Location
@@ -167,6 +185,11 @@ module Network.Google.CloudTasks
     -- ** QueueState
     , QueueState (..)
 
+    -- ** GetPolicyOptions
+    , GetPolicyOptions
+    , getPolicyOptions
+    , gpoRequestedPolicyVersion
+
     -- ** CreateTaskRequestResponseView
     , CreateTaskRequestResponseView (..)
 
@@ -182,11 +205,27 @@ module Network.Google.CloudTasks
     , qAppEngineRoutingOverride
     , qState
     , qRetryConfig
+    , qStackdriverLoggingConfig
     , qName
     , qPurgeTime
 
     -- ** AppEngineHTTPRequestHTTPMethod
     , AppEngineHTTPRequestHTTPMethod (..)
+
+    -- ** HTTPRequest
+    , HTTPRequest
+    , hTTPRequest
+    , httprOAuthToken
+    , httprHTTPMethod
+    , httprOidcToken
+    , httprBody
+    , httprURL
+    , httprHeaders
+
+    -- ** StackdriverLoggingConfig
+    , StackdriverLoggingConfig
+    , stackdriverLoggingConfig
+    , slcSamplingRatio
 
     -- ** ListTasksResponse
     , ListTasksResponse
@@ -229,6 +268,7 @@ module Network.Google.CloudTasks
     , tLastAttempt
     , tDispatchDeadline
     , tScheduleTime
+    , tHTTPRequest
     , tName
     , tFirstAttempt
     , tView
@@ -270,6 +310,9 @@ module Network.Google.CloudTasks
     , aerHost
     , aerInstance
 
+    -- ** HTTPRequestHTTPMethod
+    , HTTPRequestHTTPMethod (..)
+
     -- ** AppEngineHTTPRequest
     , AppEngineHTTPRequest
     , appEngineHTTPRequest
@@ -291,26 +334,26 @@ module Network.Google.CloudTasks
     , bCondition
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Get
-import           Network.Google.Resource.CloudTasks.Projects.Locations.List
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Create
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Delete
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Get
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.GetIAMPolicy
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.List
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Patch
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Pause
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Purge
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Resume
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.SetIAMPolicy
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Create
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Delete
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Get
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.List
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Run
-import           Network.Google.Resource.CloudTasks.Projects.Locations.Queues.TestIAMPermissions
+import Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Resource.CloudTasks.Projects.Locations.Get
+import Network.Google.Resource.CloudTasks.Projects.Locations.List
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Create
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Delete
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Get
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.GetIAMPolicy
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.List
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Patch
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Pause
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Purge
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Resume
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.SetIAMPolicy
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Create
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Delete
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Get
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.List
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Run
+import Network.Google.Resource.CloudTasks.Projects.Locations.Queues.TestIAMPermissions
 
 {- $resources
 TODO

--- a/gogol-cloudtasks/gen/Network/Google/CloudTasks/Types.hs
+++ b/gogol-cloudtasks/gen/Network/Google/CloudTasks/Types.hs
@@ -1,5 +1,5 @@
-{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -29,6 +29,12 @@ module Network.Google.CloudTasks.Types
     , rlMaxDispatchesPerSecond
     , rlMaxBurstSize
 
+    -- * OAuthToken
+    , OAuthToken
+    , oAuthToken
+    , oatScope
+    , oatServiceAccountEmail
+
     -- * Status
     , Status
     , status
@@ -53,6 +59,13 @@ module Network.Google.CloudTasks.Types
     -- * GetIAMPolicyRequest
     , GetIAMPolicyRequest
     , getIAMPolicyRequest
+    , giprOptions
+
+    -- * OidcToken
+    , OidcToken
+    , oidcToken
+    , otAudience
+    , otServiceAccountEmail
 
     -- * RetryConfig
     , RetryConfig
@@ -67,6 +80,11 @@ module Network.Google.CloudTasks.Types
     , RunTaskRequest
     , runTaskRequest
     , rtrResponseView
+
+    -- * HTTPRequestHeaders
+    , HTTPRequestHeaders
+    , hTTPRequestHeaders
+    , httprhAddtional
 
     -- * Location
     , Location
@@ -104,6 +122,11 @@ module Network.Google.CloudTasks.Types
     -- * QueueState
     , QueueState (..)
 
+    -- * GetPolicyOptions
+    , GetPolicyOptions
+    , getPolicyOptions
+    , gpoRequestedPolicyVersion
+
     -- * CreateTaskRequestResponseView
     , CreateTaskRequestResponseView (..)
 
@@ -119,11 +142,27 @@ module Network.Google.CloudTasks.Types
     , qAppEngineRoutingOverride
     , qState
     , qRetryConfig
+    , qStackdriverLoggingConfig
     , qName
     , qPurgeTime
 
     -- * AppEngineHTTPRequestHTTPMethod
     , AppEngineHTTPRequestHTTPMethod (..)
+
+    -- * HTTPRequest
+    , HTTPRequest
+    , hTTPRequest
+    , httprOAuthToken
+    , httprHTTPMethod
+    , httprOidcToken
+    , httprBody
+    , httprURL
+    , httprHeaders
+
+    -- * StackdriverLoggingConfig
+    , StackdriverLoggingConfig
+    , stackdriverLoggingConfig
+    , slcSamplingRatio
 
     -- * ListTasksResponse
     , ListTasksResponse
@@ -166,6 +205,7 @@ module Network.Google.CloudTasks.Types
     , tLastAttempt
     , tDispatchDeadline
     , tScheduleTime
+    , tHTTPRequest
     , tName
     , tFirstAttempt
     , tView
@@ -207,6 +247,9 @@ module Network.Google.CloudTasks.Types
     , aerHost
     , aerInstance
 
+    -- * HTTPRequestHTTPMethod
+    , HTTPRequestHTTPMethod (..)
+
     -- * AppEngineHTTPRequest
     , AppEngineHTTPRequest
     , appEngineHTTPRequest
@@ -228,9 +271,9 @@ module Network.Google.CloudTasks.Types
     , bCondition
     ) where
 
-import           Network.Google.CloudTasks.Types.Product
-import           Network.Google.CloudTasks.Types.Sum
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types.Product
+import Network.Google.CloudTasks.Types.Sum
+import Network.Google.Prelude
 
 -- | Default request referring to version 'v2' of the Cloud Tasks API. This contains the host and root path used as a starting point for constructing service requests.
 cloudTasksService :: ServiceConfig

--- a/gogol-cloudtasks/gen/Network/Google/CloudTasks/Types/Product.hs
+++ b/gogol-cloudtasks/gen/Network/Google/CloudTasks/Types/Product.hs
@@ -17,8 +17,8 @@
 --
 module Network.Google.CloudTasks.Types.Product where
 
-import           Network.Google.CloudTasks.Types.Sum
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types.Sum
+import Network.Google.Prelude
 
 -- | Rate limits. This message determines the maximum rate that tasks can be
 -- dispatched by a queue, regardless of whether the dispatch is a first
@@ -29,8 +29,8 @@ import           Network.Google.Prelude
 data RateLimits =
   RateLimits'
     { _rlMaxConcurrentDispatches :: !(Maybe (Textual Int32))
-    , _rlMaxDispatchesPerSecond  :: !(Maybe (Textual Double))
-    , _rlMaxBurstSize            :: !(Maybe (Textual Int32))
+    , _rlMaxDispatchesPerSecond :: !(Maybe (Textual Double))
+    , _rlMaxBurstSize :: !(Maybe (Textual Int32))
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -69,8 +69,8 @@ rlMaxConcurrentDispatches
 
 -- | The maximum rate at which tasks are dispatched from this queue. If
 -- unspecified when the queue is created, Cloud Tasks will pick the
--- default. * For App Engine queues, the maximum allowed value is 500. This
--- field has the same meaning as [rate in
+-- default. * The maximum allowed value is 500. This field has the same
+-- meaning as [rate in
 -- queue.yaml\/xml](https:\/\/cloud.google.com\/appengine\/docs\/standard\/python\/config\/queueref#rate).
 rlMaxDispatchesPerSecond :: Lens' RateLimits (Maybe Double)
 rlMaxDispatchesPerSecond
@@ -91,8 +91,8 @@ rlMaxDispatchesPerSecond
 -- The bucket will be continuously refilled with new tokens based on
 -- max_dispatches_per_second. Cloud Tasks will pick the value of
 -- \`max_burst_size\` based on the value of max_dispatches_per_second. For
--- App Engine queues that were created or updated using
--- \`queue.yaml\/xml\`, \`max_burst_size\` is equal to
+-- queues that were created or updated using \`queue.yaml\/xml\`,
+-- \`max_burst_size\` is equal to
 -- [bucket_size](https:\/\/cloud.google.com\/appengine\/docs\/standard\/python\/config\/queueref#bucket_size).
 -- Since \`max_burst_size\` is output only, if UpdateQueue is called on a
 -- queue created by \`queue.yaml\/xml\`, \`max_burst_size\` will be reset
@@ -123,47 +123,77 @@ instance ToJSON RateLimits where
                     _rlMaxDispatchesPerSecond,
                   ("maxBurstSize" .=) <$> _rlMaxBurstSize])
 
+-- | Contains information needed for generating an [OAuth
+-- token](https:\/\/developers.google.com\/identity\/protocols\/OAuth2).
+-- This type of authorization should generally only be used when calling
+-- Google APIs hosted on *.googleapis.com.
+--
+-- /See:/ 'oAuthToken' smart constructor.
+data OAuthToken =
+  OAuthToken'
+    { _oatScope :: !(Maybe Text)
+    , _oatServiceAccountEmail :: !(Maybe Text)
+    }
+  deriving (Eq, Show, Data, Typeable, Generic)
+
+
+-- | Creates a value of 'OAuthToken' with the minimum fields required to make a request.
+--
+-- Use one of the following lenses to modify other fields as desired:
+--
+-- * 'oatScope'
+--
+-- * 'oatServiceAccountEmail'
+oAuthToken
+    :: OAuthToken
+oAuthToken =
+  OAuthToken' {_oatScope = Nothing, _oatServiceAccountEmail = Nothing}
+
+
+-- | OAuth scope to be used for generating OAuth access token. If not
+-- specified, \"https:\/\/www.googleapis.com\/auth\/cloud-platform\" will
+-- be used.
+oatScope :: Lens' OAuthToken (Maybe Text)
+oatScope = lens _oatScope (\ s a -> s{_oatScope = a})
+
+-- | [Service account
+-- email](https:\/\/cloud.google.com\/iam\/docs\/service-accounts) to be
+-- used for generating OAuth token. The service account must be within the
+-- same project as the queue. The caller must have
+-- iam.serviceAccounts.actAs permission for the service account.
+oatServiceAccountEmail :: Lens' OAuthToken (Maybe Text)
+oatServiceAccountEmail
+  = lens _oatServiceAccountEmail
+      (\ s a -> s{_oatServiceAccountEmail = a})
+
+instance FromJSON OAuthToken where
+        parseJSON
+          = withObject "OAuthToken"
+              (\ o ->
+                 OAuthToken' <$>
+                   (o .:? "scope") <*> (o .:? "serviceAccountEmail"))
+
+instance ToJSON OAuthToken where
+        toJSON OAuthToken'{..}
+          = object
+              (catMaybes
+                 [("scope" .=) <$> _oatScope,
+                  ("serviceAccountEmail" .=) <$>
+                    _oatServiceAccountEmail])
+
 -- | The \`Status\` type defines a logical error model that is suitable for
 -- different programming environments, including REST APIs and RPC APIs. It
--- is used by [gRPC](https:\/\/github.com\/grpc). The error model is
--- designed to be: - Simple to use and understand for most users - Flexible
--- enough to meet unexpected needs # Overview The \`Status\` message
+-- is used by [gRPC](https:\/\/github.com\/grpc). Each \`Status\` message
 -- contains three pieces of data: error code, error message, and error
--- details. The error code should be an enum value of google.rpc.Code, but
--- it may accept additional error codes if needed. The error message should
--- be a developer-facing English message that helps developers *understand*
--- and *resolve* the error. If a localized user-facing error message is
--- needed, put the localized message in the error details or localize it in
--- the client. The optional error details may contain arbitrary information
--- about the error. There is a predefined set of error detail types in the
--- package \`google.rpc\` that can be used for common error conditions. #
--- Language mapping The \`Status\` message is the logical representation of
--- the error model, but it is not necessarily the actual wire format. When
--- the \`Status\` message is exposed in different client libraries and
--- different wire protocols, it can be mapped differently. For example, it
--- will likely be mapped to some exceptions in Java, but more likely mapped
--- to some error codes in C. # Other uses The error model and the
--- \`Status\` message can be used in a variety of environments, either with
--- or without APIs, to provide a consistent developer experience across
--- different environments. Example uses of this error model include: -
--- Partial errors. If a service needs to return partial errors to the
--- client, it may embed the \`Status\` in the normal response to indicate
--- the partial errors. - Workflow errors. A typical workflow has multiple
--- steps. Each step may have a \`Status\` message for error reporting. -
--- Batch operations. If a client uses batch request and batch response, the
--- \`Status\` message should be used directly inside batch response, one
--- for each error sub-response. - Asynchronous operations. If an API call
--- embeds asynchronous operation results in its response, the status of
--- those operations should be represented directly using the \`Status\`
--- message. - Logging. If some API errors are stored in logs, the message
--- \`Status\` could be used directly after any stripping needed for
--- security\/privacy reasons.
+-- details. You can find out more about this error model and how to work
+-- with it in the [API Design
+-- Guide](https:\/\/cloud.google.com\/apis\/design\/errors).
 --
 -- /See:/ 'status' smart constructor.
 data Status =
   Status'
     { _sDetails :: !(Maybe [StatusDetailsItem])
-    , _sCode    :: !(Maybe (Textual Int32))
+    , _sCode :: !(Maybe (Textual Int32))
     , _sMessage :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
@@ -219,16 +249,30 @@ instance ToJSON Status where
                   ("code" .=) <$> _sCode,
                   ("message" .=) <$> _sMessage])
 
--- | Represents an expression text. Example: title: \"User account presence\"
--- description: \"Determines whether the request has a user account\"
--- expression: \"size(request.user) > 0\"
+-- | Represents a textual expression in the Common Expression Language (CEL)
+-- syntax. CEL is a C-like expression language. The syntax and semantics of
+-- CEL are documented at https:\/\/github.com\/google\/cel-spec. Example
+-- (Comparison): title: \"Summary size limit\" description: \"Determines if
+-- a summary is less than 100 chars\" expression: \"document.summary.size()
+-- \< 100\" Example (Equality): title: \"Requestor is owner\" description:
+-- \"Determines if requestor is the document owner\" expression:
+-- \"document.owner == request.auth.claims.email\" Example (Logic): title:
+-- \"Public documents\" description: \"Determine whether the document
+-- should be publicly visible\" expression: \"document.type != \'private\'
+-- && document.type != \'internal\'\" Example (Data Manipulation): title:
+-- \"Notification string\" description: \"Create a notification string with
+-- a timestamp.\" expression: \"\'New message received at \' +
+-- string(document.create_time)\" The exact variables and functions that
+-- may be referenced within an expression are determined by the service
+-- that evaluates it. See the service documentation for additional
+-- information.
 --
 -- /See:/ 'expr' smart constructor.
 data Expr =
   Expr'
-    { _eLocation    :: !(Maybe Text)
-    , _eExpression  :: !(Maybe Text)
-    , _eTitle       :: !(Maybe Text)
+    { _eLocation :: !(Maybe Text)
+    , _eExpression :: !(Maybe Text)
+    , _eTitle :: !(Maybe Text)
     , _eDescription :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
@@ -256,26 +300,25 @@ expr =
     }
 
 
--- | An optional string indicating the location of the expression for error
+-- | Optional. String indicating the location of the expression for error
 -- reporting, e.g. a file name and a position in the file.
 eLocation :: Lens' Expr (Maybe Text)
 eLocation
   = lens _eLocation (\ s a -> s{_eLocation = a})
 
 -- | Textual representation of an expression in Common Expression Language
--- syntax. The application context of the containing message determines
--- which well-known feature set of CEL is supported.
+-- syntax.
 eExpression :: Lens' Expr (Maybe Text)
 eExpression
   = lens _eExpression (\ s a -> s{_eExpression = a})
 
--- | An optional title for the expression, i.e. a short string describing its
+-- | Optional. Title for the expression, i.e. a short string describing its
 -- purpose. This can be used e.g. in UIs which allow to enter the
 -- expression.
 eTitle :: Lens' Expr (Maybe Text)
 eTitle = lens _eTitle (\ s a -> s{_eTitle = a})
 
--- | An optional description of the expression. This is a longer text which
+-- | Optional. Description of the expression. This is a longer text which
 -- describes the expression, e.g. when hovered over it in a UI.
 eDescription :: Lens' Expr (Maybe Text)
 eDescription
@@ -305,7 +348,7 @@ instance ToJSON Expr where
 data ListLocationsResponse =
   ListLocationsResponse'
     { _llrNextPageToken :: !(Maybe Text)
-    , _llrLocations     :: !(Maybe [Location])
+    , _llrLocations :: !(Maybe [Location])
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -354,25 +397,96 @@ instance ToJSON ListLocationsResponse where
 -- | Request message for \`GetIamPolicy\` method.
 --
 -- /See:/ 'getIAMPolicyRequest' smart constructor.
-data GetIAMPolicyRequest =
+newtype GetIAMPolicyRequest =
   GetIAMPolicyRequest'
+    { _giprOptions :: Maybe GetPolicyOptions
+    }
   deriving (Eq, Show, Data, Typeable, Generic)
 
 
 -- | Creates a value of 'GetIAMPolicyRequest' with the minimum fields required to make a request.
 --
+-- Use one of the following lenses to modify other fields as desired:
+--
+-- * 'giprOptions'
 getIAMPolicyRequest
     :: GetIAMPolicyRequest
-getIAMPolicyRequest = GetIAMPolicyRequest'
+getIAMPolicyRequest = GetIAMPolicyRequest' {_giprOptions = Nothing}
 
+
+-- | OPTIONAL: A \`GetPolicyOptions\` object for specifying options to
+-- \`GetIamPolicy\`.
+giprOptions :: Lens' GetIAMPolicyRequest (Maybe GetPolicyOptions)
+giprOptions
+  = lens _giprOptions (\ s a -> s{_giprOptions = a})
 
 instance FromJSON GetIAMPolicyRequest where
         parseJSON
           = withObject "GetIAMPolicyRequest"
-              (\ o -> pure GetIAMPolicyRequest')
+              (\ o -> GetIAMPolicyRequest' <$> (o .:? "options"))
 
 instance ToJSON GetIAMPolicyRequest where
-        toJSON = const emptyObject
+        toJSON GetIAMPolicyRequest'{..}
+          = object
+              (catMaybes [("options" .=) <$> _giprOptions])
+
+-- | Contains information needed for generating an [OpenID Connect
+-- token](https:\/\/developers.google.com\/identity\/protocols\/OpenIDConnect).
+-- This type of authorization can be used for many scenarios, including
+-- calling Cloud Run, or endpoints where you intend to validate the token
+-- yourself.
+--
+-- /See:/ 'oidcToken' smart constructor.
+data OidcToken =
+  OidcToken'
+    { _otAudience :: !(Maybe Text)
+    , _otServiceAccountEmail :: !(Maybe Text)
+    }
+  deriving (Eq, Show, Data, Typeable, Generic)
+
+
+-- | Creates a value of 'OidcToken' with the minimum fields required to make a request.
+--
+-- Use one of the following lenses to modify other fields as desired:
+--
+-- * 'otAudience'
+--
+-- * 'otServiceAccountEmail'
+oidcToken
+    :: OidcToken
+oidcToken = OidcToken' {_otAudience = Nothing, _otServiceAccountEmail = Nothing}
+
+
+-- | Audience to be used when generating OIDC token. If not specified, the
+-- URI specified in target will be used.
+otAudience :: Lens' OidcToken (Maybe Text)
+otAudience
+  = lens _otAudience (\ s a -> s{_otAudience = a})
+
+-- | [Service account
+-- email](https:\/\/cloud.google.com\/iam\/docs\/service-accounts) to be
+-- used for generating OIDC token. The service account must be within the
+-- same project as the queue. The caller must have
+-- iam.serviceAccounts.actAs permission for the service account.
+otServiceAccountEmail :: Lens' OidcToken (Maybe Text)
+otServiceAccountEmail
+  = lens _otServiceAccountEmail
+      (\ s a -> s{_otServiceAccountEmail = a})
+
+instance FromJSON OidcToken where
+        parseJSON
+          = withObject "OidcToken"
+              (\ o ->
+                 OidcToken' <$>
+                   (o .:? "audience") <*> (o .:? "serviceAccountEmail"))
+
+instance ToJSON OidcToken where
+        toJSON OidcToken'{..}
+          = object
+              (catMaybes
+                 [("audience" .=) <$> _otAudience,
+                  ("serviceAccountEmail" .=) <$>
+                    _otServiceAccountEmail])
 
 -- | Retry config. These settings determine when a failed task attempt is
 -- retried.
@@ -380,11 +494,11 @@ instance ToJSON GetIAMPolicyRequest where
 -- /See:/ 'retryConfig' smart constructor.
 data RetryConfig =
   RetryConfig'
-    { _rcMaxDoublings     :: !(Maybe (Textual Int32))
+    { _rcMaxDoublings :: !(Maybe (Textual Int32))
     , _rcMaxRetryDuration :: !(Maybe GDuration)
-    , _rcMaxAttempts      :: !(Maybe (Textual Int32))
-    , _rcMaxBackoff       :: !(Maybe GDuration)
-    , _rcMinBackoff       :: !(Maybe GDuration)
+    , _rcMaxAttempts :: !(Maybe (Textual Int32))
+    , _rcMaxBackoff :: !(Maybe GDuration)
+    , _rcMinBackoff :: !(Maybe GDuration)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -416,8 +530,8 @@ retryConfig =
 
 -- | The time between retries will double \`max_doublings\` times. A task\'s
 -- retry interval starts at min_backoff, then doubles \`max_doublings\`
--- times, then increases linearly, and finally retries retries at intervals
--- of max_backoff up to max_attempts times. For example, if min_backoff is
+-- times, then increases linearly, and finally retries at intervals of
+-- max_backoff up to max_attempts times. For example, if min_backoff is
 -- 10s, max_backoff is 300s, and \`max_doublings\` is 3, then the a task
 -- will first be retried in 10s. The retry interval will double three
 -- times, and then increase linearly by 2^3 * 10s. Finally, the task will
@@ -548,16 +662,66 @@ instance ToJSON RunTaskRequest where
               (catMaybes
                  [("responseView" .=) <$> _rtrResponseView])
 
+-- | HTTP request headers. This map contains the header field names and
+-- values. Headers can be set when the task is created. These headers
+-- represent a subset of the headers that will accompany the task\'s HTTP
+-- request. Some HTTP request headers will be ignored or replaced. A
+-- partial list of headers that will be ignored or replaced is: * Host:
+-- This will be computed by Cloud Tasks and derived from HttpRequest.url. *
+-- Content-Length: This will be computed by Cloud Tasks. * User-Agent: This
+-- will be set to \`\"Google-Cloud-Tasks\"\`. * X-Google-*: Google use
+-- only. * X-AppEngine-*: Google use only. \`Content-Type\` won\'t be set
+-- by Cloud Tasks. You can explicitly set \`Content-Type\` to a media type
+-- when the task is created. For example, \`Content-Type\` can be set to
+-- \`\"application\/octet-stream\"\` or \`\"application\/json\"\`. Headers
+-- which can have multiple values (according to RFC2616) can be specified
+-- using comma-separated values. The size of the headers must be less than
+-- 80KB.
+--
+-- /See:/ 'hTTPRequestHeaders' smart constructor.
+newtype HTTPRequestHeaders =
+  HTTPRequestHeaders'
+    { _httprhAddtional :: HashMap Text Text
+    }
+  deriving (Eq, Show, Data, Typeable, Generic)
+
+
+-- | Creates a value of 'HTTPRequestHeaders' with the minimum fields required to make a request.
+--
+-- Use one of the following lenses to modify other fields as desired:
+--
+-- * 'httprhAddtional'
+hTTPRequestHeaders
+    :: HashMap Text Text -- ^ 'httprhAddtional'
+    -> HTTPRequestHeaders
+hTTPRequestHeaders pHttprhAddtional_ =
+  HTTPRequestHeaders' {_httprhAddtional = _Coerce # pHttprhAddtional_}
+
+
+httprhAddtional :: Lens' HTTPRequestHeaders (HashMap Text Text)
+httprhAddtional
+  = lens _httprhAddtional
+      (\ s a -> s{_httprhAddtional = a})
+      . _Coerce
+
+instance FromJSON HTTPRequestHeaders where
+        parseJSON
+          = withObject "HTTPRequestHeaders"
+              (\ o -> HTTPRequestHeaders' <$> (parseJSONObject o))
+
+instance ToJSON HTTPRequestHeaders where
+        toJSON = toJSON . _httprhAddtional
+
 -- | A resource that represents Google Cloud Platform location.
 --
 -- /See:/ 'location' smart constructor.
 data Location =
   Location'
-    { _lName        :: !(Maybe Text)
-    , _lMetadata    :: !(Maybe LocationMetadata)
+    { _lName :: !(Maybe Text)
+    , _lMetadata :: !(Maybe LocationMetadata)
     , _lDisplayName :: !(Maybe Text)
-    , _lLabels      :: !(Maybe LocationLabels)
-    , _lLocationId  :: !(Maybe Text)
+    , _lLabels :: !(Maybe LocationLabels)
+    , _lLocationId :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -665,7 +829,7 @@ instance ToJSON Empty where
 data CreateTaskRequest =
   CreateTaskRequest'
     { _ctrResponseView :: !(Maybe CreateTaskRequestResponseView)
-    , _ctrTask         :: !(Maybe Task)
+    , _ctrTask :: !(Maybe Task)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -740,7 +904,7 @@ instance ToJSON CreateTaskRequest where
 data ListQueuesResponse =
   ListQueuesResponse'
     { _lqrNextPageToken :: !(Maybe Text)
-    , _lqrQueues        :: !(Maybe [Queue])
+    , _lqrQueues :: !(Maybe [Queue])
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -824,6 +988,53 @@ instance FromJSON StatusDetailsItem where
 instance ToJSON StatusDetailsItem where
         toJSON = toJSON . _sdiAddtional
 
+-- | Encapsulates settings provided to GetIamPolicy.
+--
+-- /See:/ 'getPolicyOptions' smart constructor.
+newtype GetPolicyOptions =
+  GetPolicyOptions'
+    { _gpoRequestedPolicyVersion :: Maybe (Textual Int32)
+    }
+  deriving (Eq, Show, Data, Typeable, Generic)
+
+
+-- | Creates a value of 'GetPolicyOptions' with the minimum fields required to make a request.
+--
+-- Use one of the following lenses to modify other fields as desired:
+--
+-- * 'gpoRequestedPolicyVersion'
+getPolicyOptions
+    :: GetPolicyOptions
+getPolicyOptions = GetPolicyOptions' {_gpoRequestedPolicyVersion = Nothing}
+
+
+-- | Optional. The policy format version to be returned. Valid values are 0,
+-- 1, and 3. Requests specifying an invalid value will be rejected.
+-- Requests for policies with any conditional bindings must specify version
+-- 3. Policies without any conditional bindings may specify any valid value
+-- or leave the field unset. To learn which resources support conditions in
+-- their IAM policies, see the [IAM
+-- documentation](https:\/\/cloud.google.com\/iam\/help\/conditions\/resource-policies).
+gpoRequestedPolicyVersion :: Lens' GetPolicyOptions (Maybe Int32)
+gpoRequestedPolicyVersion
+  = lens _gpoRequestedPolicyVersion
+      (\ s a -> s{_gpoRequestedPolicyVersion = a})
+      . mapping _Coerce
+
+instance FromJSON GetPolicyOptions where
+        parseJSON
+          = withObject "GetPolicyOptions"
+              (\ o ->
+                 GetPolicyOptions' <$>
+                   (o .:? "requestedPolicyVersion"))
+
+instance ToJSON GetPolicyOptions where
+        toJSON GetPolicyOptions'{..}
+          = object
+              (catMaybes
+                 [("requestedPolicyVersion" .=) <$>
+                    _gpoRequestedPolicyVersion])
+
 -- | Request message for \`SetIamPolicy\` method.
 --
 -- /See:/ 'setIAMPolicyRequest' smart constructor.
@@ -868,12 +1079,13 @@ instance ToJSON SetIAMPolicyRequest where
 -- /See:/ 'queue' smart constructor.
 data Queue =
   Queue'
-    { _qRateLimits               :: !(Maybe RateLimits)
+    { _qRateLimits :: !(Maybe RateLimits)
     , _qAppEngineRoutingOverride :: !(Maybe AppEngineRouting)
-    , _qState                    :: !(Maybe QueueState)
-    , _qRetryConfig              :: !(Maybe RetryConfig)
-    , _qName                     :: !(Maybe Text)
-    , _qPurgeTime                :: !(Maybe DateTime')
+    , _qState :: !(Maybe QueueState)
+    , _qRetryConfig :: !(Maybe RetryConfig)
+    , _qStackdriverLoggingConfig :: !(Maybe StackdriverLoggingConfig)
+    , _qName :: !(Maybe Text)
+    , _qPurgeTime :: !(Maybe DateTime')
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -890,6 +1102,8 @@ data Queue =
 --
 -- * 'qRetryConfig'
 --
+-- * 'qStackdriverLoggingConfig'
+--
 -- * 'qName'
 --
 -- * 'qPurgeTime'
@@ -901,6 +1115,7 @@ queue =
     , _qAppEngineRoutingOverride = Nothing
     , _qState = Nothing
     , _qRetryConfig = Nothing
+    , _qStackdriverLoggingConfig = Nothing
     , _qName = Nothing
     , _qPurgeTime = Nothing
     }
@@ -924,7 +1139,7 @@ qRateLimits
   = lens _qRateLimits (\ s a -> s{_qRateLimits = a})
 
 -- | Overrides for task-level app_engine_routing. These settings apply only
--- to App Engine tasks in this queue. If set,
+-- to App Engine tasks in this queue. Http tasks are not affected. If set,
 -- \`app_engine_routing_override\` is used for all App Engine tasks in the
 -- queue, no matter what the setting is for the task-level
 -- app_engine_routing.
@@ -951,6 +1166,14 @@ qState = lens _qState (\ s a -> s{_qState = a})
 qRetryConfig :: Lens' Queue (Maybe RetryConfig)
 qRetryConfig
   = lens _qRetryConfig (\ s a -> s{_qRetryConfig = a})
+
+-- | Configuration options for writing logs to [Stackdriver
+-- Logging](https:\/\/cloud.google.com\/logging\/docs\/). If this field is
+-- unset, then no logs are written.
+qStackdriverLoggingConfig :: Lens' Queue (Maybe StackdriverLoggingConfig)
+qStackdriverLoggingConfig
+  = lens _qStackdriverLoggingConfig
+      (\ s a -> s{_qStackdriverLoggingConfig = a})
 
 -- | Caller-specified and required in CreateQueue, after which it becomes
 -- output only. The queue name. The queue name must have the following
@@ -988,6 +1211,7 @@ instance FromJSON Queue where
                      (o .:? "appEngineRoutingOverride")
                      <*> (o .:? "state")
                      <*> (o .:? "retryConfig")
+                     <*> (o .:? "stackdriverLoggingConfig")
                      <*> (o .:? "name")
                      <*> (o .:? "purgeTime"))
 
@@ -1000,8 +1224,202 @@ instance ToJSON Queue where
                     _qAppEngineRoutingOverride,
                   ("state" .=) <$> _qState,
                   ("retryConfig" .=) <$> _qRetryConfig,
+                  ("stackdriverLoggingConfig" .=) <$>
+                    _qStackdriverLoggingConfig,
                   ("name" .=) <$> _qName,
                   ("purgeTime" .=) <$> _qPurgeTime])
+
+-- | HTTP request. The task will be pushed to the worker as an HTTP request.
+-- If the worker or the redirected worker acknowledges the task by
+-- returning a successful HTTP response code ([\`200\` - \`299\`]), the
+-- task will be removed from the queue. If any other HTTP response code is
+-- returned or no response is received, the task will be retried according
+-- to the following: * User-specified throttling: retry configuration, rate
+-- limits, and the queue\'s state. * System throttling: To prevent the
+-- worker from overloading, Cloud Tasks may temporarily reduce the queue\'s
+-- effective rate. User-specified settings will not be changed. System
+-- throttling happens because: * Cloud Tasks backs off on all errors.
+-- Normally the backoff specified in rate limits will be used. But if the
+-- worker returns \`429\` (Too Many Requests), \`503\` (Service
+-- Unavailable), or the rate of errors is high, Cloud Tasks will use a
+-- higher backoff rate. The retry specified in the \`Retry-After\` HTTP
+-- response header is considered. * To prevent traffic spikes and to smooth
+-- sudden increases in traffic, dispatches ramp up slowly when the queue is
+-- newly created or idle and if large numbers of tasks suddenly become
+-- available to dispatch (due to spikes in create task rates, the queue
+-- being unpaused, or many tasks that are scheduled at the same time).
+--
+-- /See:/ 'hTTPRequest' smart constructor.
+data HTTPRequest =
+  HTTPRequest'
+    { _httprOAuthToken :: !(Maybe OAuthToken)
+    , _httprHTTPMethod :: !(Maybe HTTPRequestHTTPMethod)
+    , _httprOidcToken :: !(Maybe OidcToken)
+    , _httprBody :: !(Maybe Bytes)
+    , _httprURL :: !(Maybe Text)
+    , _httprHeaders :: !(Maybe HTTPRequestHeaders)
+    }
+  deriving (Eq, Show, Data, Typeable, Generic)
+
+
+-- | Creates a value of 'HTTPRequest' with the minimum fields required to make a request.
+--
+-- Use one of the following lenses to modify other fields as desired:
+--
+-- * 'httprOAuthToken'
+--
+-- * 'httprHTTPMethod'
+--
+-- * 'httprOidcToken'
+--
+-- * 'httprBody'
+--
+-- * 'httprURL'
+--
+-- * 'httprHeaders'
+hTTPRequest
+    :: HTTPRequest
+hTTPRequest =
+  HTTPRequest'
+    { _httprOAuthToken = Nothing
+    , _httprHTTPMethod = Nothing
+    , _httprOidcToken = Nothing
+    , _httprBody = Nothing
+    , _httprURL = Nothing
+    , _httprHeaders = Nothing
+    }
+
+
+-- | If specified, an [OAuth
+-- token](https:\/\/developers.google.com\/identity\/protocols\/OAuth2)
+-- will be generated and attached as an \`Authorization\` header in the
+-- HTTP request. This type of authorization should generally only be used
+-- when calling Google APIs hosted on *.googleapis.com.
+httprOAuthToken :: Lens' HTTPRequest (Maybe OAuthToken)
+httprOAuthToken
+  = lens _httprOAuthToken
+      (\ s a -> s{_httprOAuthToken = a})
+
+-- | The HTTP method to use for the request. The default is POST.
+httprHTTPMethod :: Lens' HTTPRequest (Maybe HTTPRequestHTTPMethod)
+httprHTTPMethod
+  = lens _httprHTTPMethod
+      (\ s a -> s{_httprHTTPMethod = a})
+
+-- | If specified, an
+-- [OIDC](https:\/\/developers.google.com\/identity\/protocols\/OpenIDConnect)
+-- token will be generated and attached as an \`Authorization\` header in
+-- the HTTP request. This type of authorization can be used for many
+-- scenarios, including calling Cloud Run, or endpoints where you intend to
+-- validate the token yourself.
+httprOidcToken :: Lens' HTTPRequest (Maybe OidcToken)
+httprOidcToken
+  = lens _httprOidcToken
+      (\ s a -> s{_httprOidcToken = a})
+
+-- | HTTP request body. A request body is allowed only if the HTTP method is
+-- POST, PUT, or PATCH. It is an error to set body on a task with an
+-- incompatible HttpMethod.
+httprBody :: Lens' HTTPRequest (Maybe ByteString)
+httprBody
+  = lens _httprBody (\ s a -> s{_httprBody = a}) .
+      mapping _Bytes
+
+-- | Required. The full url path that the request will be sent to. This
+-- string must begin with either \"http:\/\/\" or \"https:\/\/\". Some
+-- examples are: \`http:\/\/acme.com\` and
+-- \`https:\/\/acme.com\/sales:8080\`. Cloud Tasks will encode some
+-- characters for safety and compatibility. The maximum allowed URL length
+-- is 2083 characters after encoding. The \`Location\` header response from
+-- a redirect response [\`300\` - \`399\`] may be followed. The redirect is
+-- not counted as a separate attempt.
+httprURL :: Lens' HTTPRequest (Maybe Text)
+httprURL = lens _httprURL (\ s a -> s{_httprURL = a})
+
+-- | HTTP request headers. This map contains the header field names and
+-- values. Headers can be set when the task is created. These headers
+-- represent a subset of the headers that will accompany the task\'s HTTP
+-- request. Some HTTP request headers will be ignored or replaced. A
+-- partial list of headers that will be ignored or replaced is: * Host:
+-- This will be computed by Cloud Tasks and derived from HttpRequest.url. *
+-- Content-Length: This will be computed by Cloud Tasks. * User-Agent: This
+-- will be set to \`\"Google-Cloud-Tasks\"\`. * X-Google-*: Google use
+-- only. * X-AppEngine-*: Google use only. \`Content-Type\` won\'t be set
+-- by Cloud Tasks. You can explicitly set \`Content-Type\` to a media type
+-- when the task is created. For example, \`Content-Type\` can be set to
+-- \`\"application\/octet-stream\"\` or \`\"application\/json\"\`. Headers
+-- which can have multiple values (according to RFC2616) can be specified
+-- using comma-separated values. The size of the headers must be less than
+-- 80KB.
+httprHeaders :: Lens' HTTPRequest (Maybe HTTPRequestHeaders)
+httprHeaders
+  = lens _httprHeaders (\ s a -> s{_httprHeaders = a})
+
+instance FromJSON HTTPRequest where
+        parseJSON
+          = withObject "HTTPRequest"
+              (\ o ->
+                 HTTPRequest' <$>
+                   (o .:? "oauthToken") <*> (o .:? "httpMethod") <*>
+                     (o .:? "oidcToken")
+                     <*> (o .:? "body")
+                     <*> (o .:? "url")
+                     <*> (o .:? "headers"))
+
+instance ToJSON HTTPRequest where
+        toJSON HTTPRequest'{..}
+          = object
+              (catMaybes
+                 [("oauthToken" .=) <$> _httprOAuthToken,
+                  ("httpMethod" .=) <$> _httprHTTPMethod,
+                  ("oidcToken" .=) <$> _httprOidcToken,
+                  ("body" .=) <$> _httprBody, ("url" .=) <$> _httprURL,
+                  ("headers" .=) <$> _httprHeaders])
+
+-- | Configuration options for writing logs to [Stackdriver
+-- Logging](https:\/\/cloud.google.com\/logging\/docs\/).
+--
+-- /See:/ 'stackdriverLoggingConfig' smart constructor.
+newtype StackdriverLoggingConfig =
+  StackdriverLoggingConfig'
+    { _slcSamplingRatio :: Maybe (Textual Double)
+    }
+  deriving (Eq, Show, Data, Typeable, Generic)
+
+
+-- | Creates a value of 'StackdriverLoggingConfig' with the minimum fields required to make a request.
+--
+-- Use one of the following lenses to modify other fields as desired:
+--
+-- * 'slcSamplingRatio'
+stackdriverLoggingConfig
+    :: StackdriverLoggingConfig
+stackdriverLoggingConfig =
+  StackdriverLoggingConfig' {_slcSamplingRatio = Nothing}
+
+
+-- | Specifies the fraction of operations to write to [Stackdriver
+-- Logging](https:\/\/cloud.google.com\/logging\/docs\/). This field may
+-- contain any value between 0.0 and 1.0, inclusive. 0.0 is the default and
+-- means that no operations are logged.
+slcSamplingRatio :: Lens' StackdriverLoggingConfig (Maybe Double)
+slcSamplingRatio
+  = lens _slcSamplingRatio
+      (\ s a -> s{_slcSamplingRatio = a})
+      . mapping _Coerce
+
+instance FromJSON StackdriverLoggingConfig where
+        parseJSON
+          = withObject "StackdriverLoggingConfig"
+              (\ o ->
+                 StackdriverLoggingConfig' <$>
+                   (o .:? "samplingRatio"))
+
+instance ToJSON StackdriverLoggingConfig where
+        toJSON StackdriverLoggingConfig'{..}
+          = object
+              (catMaybes
+                 [("samplingRatio" .=) <$> _slcSamplingRatio])
 
 -- | Response message for listing tasks using ListTasks.
 --
@@ -1009,7 +1427,7 @@ instance ToJSON Queue where
 data ListTasksResponse =
   ListTasksResponse'
     { _ltrNextPageToken :: !(Maybe Text)
-    , _ltrTasks         :: !(Maybe [Task])
+    , _ltrTasks :: !(Maybe [Task])
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -1076,7 +1494,7 @@ instance ToJSON ListTasksResponse where
 -- \`X-AppEngine-*\` In addition, Cloud Tasks sets some headers when the
 -- task is dispatched, such as headers containing information about the
 -- task; see [request
--- headers](https:\/\/cloud.google.com\/appengine\/docs\/python\/taskqueue\/push\/creating-handlers#reading_request_headers).
+-- headers](https:\/\/cloud.google.com\/tasks\/docs\/creating-appengine-handlers#reading_request_headers).
 -- These headers are set only when the task is dispatched, so they are not
 -- visible when the task is returned in a Cloud Tasks response. Although
 -- there is no specific limit for the maximum number of headers or the
@@ -1192,9 +1610,9 @@ instance ToJSON TestIAMPermissionsRequest where
 data Attempt =
   Attempt'
     { _aResponseStatus :: !(Maybe Status)
-    , _aScheduleTime   :: !(Maybe DateTime')
-    , _aDispatchTime   :: !(Maybe DateTime')
-    , _aResponseTime   :: !(Maybe DateTime')
+    , _aScheduleTime :: !(Maybe DateTime')
+    , _aDispatchTime :: !(Maybe DateTime')
+    , _aResponseTime :: !(Maybe DateTime')
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -1299,16 +1717,17 @@ instance ToJSON PurgeQueueRequest where
 -- /See:/ 'task' smart constructor.
 data Task =
   Task'
-    { _tLastAttempt          :: !(Maybe Attempt)
-    , _tDispatchDeadline     :: !(Maybe GDuration)
-    , _tScheduleTime         :: !(Maybe DateTime')
-    , _tName                 :: !(Maybe Text)
-    , _tFirstAttempt         :: !(Maybe Attempt)
-    , _tView                 :: !(Maybe TaskView)
-    , _tResponseCount        :: !(Maybe (Textual Int32))
-    , _tDispatchCount        :: !(Maybe (Textual Int32))
+    { _tLastAttempt :: !(Maybe Attempt)
+    , _tDispatchDeadline :: !(Maybe GDuration)
+    , _tScheduleTime :: !(Maybe DateTime')
+    , _tHTTPRequest :: !(Maybe HTTPRequest)
+    , _tName :: !(Maybe Text)
+    , _tFirstAttempt :: !(Maybe Attempt)
+    , _tView :: !(Maybe TaskView)
+    , _tResponseCount :: !(Maybe (Textual Int32))
+    , _tDispatchCount :: !(Maybe (Textual Int32))
     , _tAppEngineHTTPRequest :: !(Maybe AppEngineHTTPRequest)
-    , _tCreateTime           :: !(Maybe DateTime')
+    , _tCreateTime :: !(Maybe DateTime')
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -1322,6 +1741,8 @@ data Task =
 -- * 'tDispatchDeadline'
 --
 -- * 'tScheduleTime'
+--
+-- * 'tHTTPRequest'
 --
 -- * 'tName'
 --
@@ -1343,6 +1764,7 @@ task =
     { _tLastAttempt = Nothing
     , _tDispatchDeadline = Nothing
     , _tScheduleTime = Nothing
+    , _tHTTPRequest = Nothing
     , _tName = Nothing
     , _tFirstAttempt = Nothing
     , _tView = Nothing
@@ -1362,12 +1784,13 @@ tLastAttempt
 -- respond by this deadline then the request is cancelled and the attempt
 -- is marked as a \`DEADLINE_EXCEEDED\` failure. Cloud Tasks will retry the
 -- task according to the RetryConfig. Note that when the request is
--- cancelled, Cloud Tasks will stop listing for the response, but whether
+-- cancelled, Cloud Tasks will stop listening for the response, but whether
 -- the worker stops processing depends on the worker. For example, if the
 -- worker is stuck, it may not react to cancelled requests. The default and
--- maximum values depend on the type of request: * For App Engine tasks, 0
--- indicates that the request has the default deadline. The default
--- deadline depends on the [scaling
+-- maximum values depend on the type of request: * For HTTP tasks, the
+-- default is 10 minutes. The deadline must be in the interval [15 seconds,
+-- 30 minutes]. * For App Engine tasks, 0 indicates that the request has
+-- the default deadline. The default deadline depends on the [scaling
 -- type](https:\/\/cloud.google.com\/appengine\/docs\/standard\/go\/how-instances-are-managed#instance_scaling)
 -- of the service: 10 minutes for standard apps with automatic scaling, 24
 -- hours for standard apps with manual and basic scaling, and 60 minutes
@@ -1386,14 +1809,19 @@ tDispatchDeadline
       (\ s a -> s{_tDispatchDeadline = a})
       . mapping _GDuration
 
--- | The time when the task is scheduled to be attempted. For App Engine
--- queues, this is when the task will be attempted or retried.
+-- | The time when the task is scheduled to be attempted or retried.
 -- \`schedule_time\` will be truncated to the nearest microsecond.
 tScheduleTime :: Lens' Task (Maybe UTCTime)
 tScheduleTime
   = lens _tScheduleTime
       (\ s a -> s{_tScheduleTime = a})
       . mapping _DateTime
+
+-- | HTTP request that is sent to the worker. An HTTP task is a task that has
+-- HttpRequest set.
+tHTTPRequest :: Lens' Task (Maybe HTTPRequest)
+tHTTPRequest
+  = lens _tHTTPRequest (\ s a -> s{_tHTTPRequest = a})
 
 -- | Optionally caller-specified in CreateTask. The task name. The task name
 -- must have the following format:
@@ -1461,6 +1889,7 @@ instance FromJSON Task where
                  Task' <$>
                    (o .:? "lastAttempt") <*> (o .:? "dispatchDeadline")
                      <*> (o .:? "scheduleTime")
+                     <*> (o .:? "httpRequest")
                      <*> (o .:? "name")
                      <*> (o .:? "firstAttempt")
                      <*> (o .:? "view")
@@ -1476,6 +1905,7 @@ instance ToJSON Task where
                  [("lastAttempt" .=) <$> _tLastAttempt,
                   ("dispatchDeadline" .=) <$> _tDispatchDeadline,
                   ("scheduleTime" .=) <$> _tScheduleTime,
+                  ("httpRequest" .=) <$> _tHTTPRequest,
                   ("name" .=) <$> _tName,
                   ("firstAttempt" .=) <$> _tFirstAttempt,
                   ("view" .=) <$> _tView,
@@ -1528,29 +1958,46 @@ instance ToJSON TestIAMPermissionsResponse where
               (catMaybes
                  [("permissions" .=) <$> _tiamprPermissions])
 
--- | Defines an Identity and Access Management (IAM) policy. It is used to
--- specify access control policies for Cloud Platform resources. A
--- \`Policy\` consists of a list of \`bindings\`. A \`binding\` binds a
--- list of \`members\` to a \`role\`, where the members can be user
--- accounts, Google groups, Google domains, and service accounts. A
--- \`role\` is a named list of permissions defined by IAM. **JSON Example**
--- { \"bindings\": [ { \"role\": \"roles\/owner\", \"members\": [
+-- | An Identity and Access Management (IAM) policy, which specifies access
+-- controls for Google Cloud resources. A \`Policy\` is a collection of
+-- \`bindings\`. A \`binding\` binds one or more \`members\` to a single
+-- \`role\`. Members can be user accounts, service accounts, Google groups,
+-- and domains (such as G Suite). A \`role\` is a named list of
+-- permissions; each \`role\` can be an IAM predefined role or a
+-- user-created custom role. For some types of Google Cloud resources, a
+-- \`binding\` can also specify a \`condition\`, which is a logical
+-- expression that allows access to a resource only if the expression
+-- evaluates to \`true\`. A condition can add constraints based on
+-- attributes of the request, the resource, or both. To learn which
+-- resources support conditions in their IAM policies, see the [IAM
+-- documentation](https:\/\/cloud.google.com\/iam\/help\/conditions\/resource-policies).
+-- **JSON example:** { \"bindings\": [ { \"role\":
+-- \"roles\/resourcemanager.organizationAdmin\", \"members\": [
 -- \"user:mike\'example.com\", \"group:admins\'example.com\",
 -- \"domain:google.com\",
--- \"serviceAccount:my-other-app\'appspot.gserviceaccount.com\" ] }, {
--- \"role\": \"roles\/viewer\", \"members\": [\"user:sean\'example.com\"] }
--- ] } **YAML Example** bindings: - members: - user:mike\'example.com -
--- group:admins\'example.com - domain:google.com -
--- serviceAccount:my-other-app\'appspot.gserviceaccount.com role:
--- roles\/owner - members: - user:sean\'example.com role: roles\/viewer For
--- a description of IAM and its features, see the [IAM developer\'s
--- guide](https:\/\/cloud.google.com\/iam\/docs).
+-- \"serviceAccount:my-project-id\'appspot.gserviceaccount.com\" ] }, {
+-- \"role\": \"roles\/resourcemanager.organizationViewer\", \"members\": [
+-- \"user:eve\'example.com\" ], \"condition\": { \"title\": \"expirable
+-- access\", \"description\": \"Does not grant access after Sep 2020\",
+-- \"expression\": \"request.time \<
+-- timestamp(\'2020-10-01T00:00:00.000Z\')\", } } ], \"etag\":
+-- \"BwWWja0YfJA=\", \"version\": 3 } **YAML example:** bindings: -
+-- members: - user:mike\'example.com - group:admins\'example.com -
+-- domain:google.com -
+-- serviceAccount:my-project-id\'appspot.gserviceaccount.com role:
+-- roles\/resourcemanager.organizationAdmin - members: -
+-- user:eve\'example.com role: roles\/resourcemanager.organizationViewer
+-- condition: title: expirable access description: Does not grant access
+-- after Sep 2020 expression: request.time \<
+-- timestamp(\'2020-10-01T00:00:00.000Z\') - etag: BwWWja0YfJA= - version:
+-- 3 For a description of IAM and its features, see the [IAM
+-- documentation](https:\/\/cloud.google.com\/iam\/docs\/).
 --
 -- /See:/ 'policy' smart constructor.
 data Policy =
   Policy'
-    { _pEtag     :: !(Maybe Bytes)
-    , _pVersion  :: !(Maybe (Textual Int32))
+    { _pEtag :: !(Maybe Bytes)
+    , _pVersion :: !(Maybe (Textual Int32))
     , _pBindings :: !(Maybe [Binding])
     }
   deriving (Eq, Show, Data, Typeable, Generic)
@@ -1577,21 +2024,40 @@ policy = Policy' {_pEtag = Nothing, _pVersion = Nothing, _pBindings = Nothing}
 -- conditions: An \`etag\` is returned in the response to \`getIamPolicy\`,
 -- and systems are expected to put that etag in the request to
 -- \`setIamPolicy\` to ensure that their change will be applied to the same
--- version of the policy. If no \`etag\` is provided in the call to
--- \`setIamPolicy\`, then the existing policy is overwritten blindly.
+-- version of the policy. **Important:** If you use IAM Conditions, you
+-- must include the \`etag\` field whenever you call \`setIamPolicy\`. If
+-- you omit this field, then IAM allows you to overwrite a version \`3\`
+-- policy with a version \`1\` policy, and all of the conditions in the
+-- version \`3\` policy are lost.
 pEtag :: Lens' Policy (Maybe ByteString)
 pEtag
   = lens _pEtag (\ s a -> s{_pEtag = a}) .
       mapping _Bytes
 
--- | Deprecated.
+-- | Specifies the format of the policy. Valid values are \`0\`, \`1\`, and
+-- \`3\`. Requests that specify an invalid value are rejected. Any
+-- operation that affects conditional role bindings must specify version
+-- \`3\`. This requirement applies to the following operations: * Getting a
+-- policy that includes a conditional role binding * Adding a conditional
+-- role binding to a policy * Changing a conditional role binding in a
+-- policy * Removing any role binding, with or without a condition, from a
+-- policy that includes conditions **Important:** If you use IAM
+-- Conditions, you must include the \`etag\` field whenever you call
+-- \`setIamPolicy\`. If you omit this field, then IAM allows you to
+-- overwrite a version \`3\` policy with a version \`1\` policy, and all of
+-- the conditions in the version \`3\` policy are lost. If a policy does
+-- not include any conditions, operations on that policy may specify any
+-- valid version or leave the field unset. To learn which resources support
+-- conditions in their IAM policies, see the [IAM
+-- documentation](https:\/\/cloud.google.com\/iam\/help\/conditions\/resource-policies).
 pVersion :: Lens' Policy (Maybe Int32)
 pVersion
   = lens _pVersion (\ s a -> s{_pVersion = a}) .
       mapping _Coerce
 
--- | Associates a list of \`members\` to a \`role\`. \`bindings\` with no
--- members will result in an error.
+-- | Associates a list of \`members\` to a \`role\`. Optionally, may specify
+-- a \`condition\` that determines how and when the \`bindings\` are
+-- applied. Each of the \`bindings\` must contain at least one member.
 pBindings :: Lens' Policy [Binding]
 pBindings
   = lens _pBindings (\ s a -> s{_pBindings = a}) .
@@ -1697,13 +2163,17 @@ instance ToJSON LocationMetadata where
 -- routing](https:\/\/cloud.google.com\/appengine\/docs\/standard\/python\/how-requests-are-routed),
 -- and [App Engine Flex request
 -- routing](https:\/\/cloud.google.com\/appengine\/docs\/flexible\/python\/how-requests-are-routed).
+-- Using AppEngineRouting requires
+-- [\`appengine.applications.get\`](https:\/\/cloud.google.com\/appengine\/docs\/admin-api\/access-control)
+-- Google IAM permission for the project and the following scope:
+-- \`https:\/\/www.googleapis.com\/auth\/cloud-platform\`
 --
 -- /See:/ 'appEngineRouting' smart constructor.
 data AppEngineRouting =
   AppEngineRouting'
-    { _aerService  :: !(Maybe Text)
-    , _aerVersion  :: !(Maybe Text)
-    , _aerHost     :: !(Maybe Text)
+    { _aerService :: !(Maybe Text)
+    , _aerVersion :: !(Maybe Text)
+    , _aerHost :: !(Maybe Text)
     , _aerInstance :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
@@ -1794,9 +2264,8 @@ instance ToJSON AppEngineRouting where
                   ("instance" .=) <$> _aerInstance])
 
 -- | App Engine HTTP request. The message defines the HTTP request that is
--- sent to an App Engine app when the task is dispatched. This proto can
--- only be used for tasks in a queue which has app_engine_http_queue set.
--- Using AppEngineHttpRequest requires
+-- sent to an App Engine app when the task is dispatched. Using
+-- AppEngineHttpRequest requires
 -- [\`appengine.applications.get\`](https:\/\/cloud.google.com\/appengine\/docs\/admin-api\/access-control)
 -- Google IAM permission for the project and the following scope:
 -- \`https:\/\/www.googleapis.com\/auth\/cloud-platform\` The task will be
@@ -1811,31 +2280,35 @@ instance ToJSON AppEngineRouting where
 -- (for example, HTTP or HTTPS). The request to the handler, however, will
 -- appear to have used the HTTP protocol. The AppEngineRouting used to
 -- construct the URL that the task is delivered to can be set at the
--- queue-level or task-level: * If set, app_engine_routing_override is used
--- for all tasks in the queue, no matter what the setting is for the
--- task-level app_engine_routing. The \`url\` that the task will be sent to
--- is: * \`url =\` host \`+\` relative_uri Tasks can be dispatched to
--- secure app handlers, unsecure app handlers, and URIs restricted with
--- [\`login:
+-- queue-level or task-level: * If app_engine_routing_override is set on
+-- the queue, this value is used for all tasks in the queue, no matter what
+-- the setting is for the task-level app_engine_routing. The \`url\` that
+-- the task will be sent to is: * \`url =\` host \`+\` relative_uri Tasks
+-- can be dispatched to secure app handlers, unsecure app handlers, and
+-- URIs restricted with [\`login:
 -- admin\`](https:\/\/cloud.google.com\/appengine\/docs\/standard\/python\/config\/appref).
 -- Because tasks are not run as any user, they cannot be dispatched to URIs
 -- restricted with [\`login:
 -- required\`](https:\/\/cloud.google.com\/appengine\/docs\/standard\/python\/config\/appref)
 -- Task dispatches also do not follow redirects. The task attempt has
 -- succeeded if the app\'s request handler returns an HTTP response code in
--- the range [\`200\` - \`299\`]. \`503\` is considered an App Engine
--- system error instead of an application error. Requests returning error
--- \`503\` will be retried regardless of retry configuration and not
--- counted against retry counts. Any other response code or a failure to
--- receive a response before the deadline is a failed attempt.
+-- the range [\`200\` - \`299\`]. The task attempt has failed if the app\'s
+-- handler returns a non-2xx response code or Cloud Tasks does not receive
+-- response before the deadline. Failed tasks will be retried according to
+-- the retry configuration. \`503\` (Service Unavailable) is considered an
+-- App Engine system error instead of an application error and will cause
+-- Cloud Tasks\' traffic congestion control to temporarily throttle the
+-- queue\'s dispatches. Unlike other types of task targets, a \`429\` (Too
+-- Many Requests) response from an app handler does not cause traffic
+-- congestion control to throttle the queue.
 --
 -- /See:/ 'appEngineHTTPRequest' smart constructor.
 data AppEngineHTTPRequest =
   AppEngineHTTPRequest'
-    { _aehttprHTTPMethod       :: !(Maybe AppEngineHTTPRequestHTTPMethod)
-    , _aehttprRelativeURI      :: !(Maybe Text)
-    , _aehttprBody             :: !(Maybe Bytes)
-    , _aehttprHeaders          :: !(Maybe AppEngineHTTPRequestHeaders)
+    { _aehttprHTTPMethod :: !(Maybe AppEngineHTTPRequestHTTPMethod)
+    , _aehttprRelativeURI :: !(Maybe Text)
+    , _aehttprBody :: !(Maybe Bytes)
+    , _aehttprHeaders :: !(Maybe AppEngineHTTPRequestHeaders)
     , _aehttprAppEngineRouting :: !(Maybe AppEngineRouting)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
@@ -1868,13 +2341,11 @@ appEngineHTTPRequest =
 
 -- | The HTTP method to use for the request. The default is POST. The app\'s
 -- request handler for the task\'s target URL must be able to handle HTTP
--- requests with this http_method, otherwise the task attempt will fail
--- with error code 405 (Method Not Allowed). See [Writing a push task
--- request
+-- requests with this http_method, otherwise the task attempt fails with
+-- error code 405 (Method Not Allowed). See [Writing a push task request
 -- handler](https:\/\/cloud.google.com\/appengine\/docs\/java\/taskqueue\/push\/creating-handlers#writing_a_push_task_request_handler)
--- and the documentation for the request handlers in the language your app
--- is written in e.g. [Python Request
--- Handler](https:\/\/cloud.google.com\/appengine\/docs\/python\/tools\/webapp\/requesthandlerclass).
+-- and the App Engine documentation for your runtime on [How Requests are
+-- Handled](https:\/\/cloud.google.com\/appengine\/docs\/standard\/python3\/how-requests-are-handled).
 aehttprHTTPMethod :: Lens' AppEngineHTTPRequest (Maybe AppEngineHTTPRequestHTTPMethod)
 aehttprHTTPMethod
   = lens _aehttprHTTPMethod
@@ -1917,7 +2388,7 @@ aehttprBody
 -- \`X-AppEngine-*\` In addition, Cloud Tasks sets some headers when the
 -- task is dispatched, such as headers containing information about the
 -- task; see [request
--- headers](https:\/\/cloud.google.com\/appengine\/docs\/python\/taskqueue\/push\/creating-handlers#reading_request_headers).
+-- headers](https:\/\/cloud.google.com\/tasks\/docs\/creating-appengine-handlers#reading_request_headers).
 -- These headers are set only when the task is dispatched, so they are not
 -- visible when the task is returned in a Cloud Tasks response. Although
 -- there is no specific limit for the maximum number of headers or the
@@ -1928,9 +2399,10 @@ aehttprHeaders
   = lens _aehttprHeaders
       (\ s a -> s{_aehttprHeaders = a})
 
--- | Task-level setting for App Engine routing. If set,
--- app_engine_routing_override is used for all tasks in the queue, no
--- matter what the setting is for the task-level app_engine_routing.
+-- | Task-level setting for App Engine routing. * If
+-- app_engine_routing_override is set on the queue, this value is used for
+-- all tasks in the queue, no matter what the setting is for the task-level
+-- app_engine_routing.
 aehttprAppEngineRouting :: Lens' AppEngineHTTPRequest (Maybe AppEngineRouting)
 aehttprAppEngineRouting
   = lens _aehttprAppEngineRouting
@@ -1985,8 +2457,8 @@ instance ToJSON ResumeQueueRequest where
 -- /See:/ 'binding' smart constructor.
 data Binding =
   Binding'
-    { _bMembers   :: !(Maybe [Text])
-    , _bRole      :: !(Maybe Text)
+    { _bMembers :: !(Maybe [Text])
+    , _bRole :: !(Maybe Text)
     , _bCondition :: !(Maybe Expr)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
@@ -2014,13 +2486,30 @@ binding =
 -- identifier that represents anyone who is authenticated with a Google
 -- account or a service account. * \`user:{emailid}\`: An email address
 -- that represents a specific Google account. For example,
--- \`alice\'gmail.com\` . * \`serviceAccount:{emailid}\`: An email address
--- that represents a service account. For example,
+-- \`alice\'example.com\` . * \`serviceAccount:{emailid}\`: An email
+-- address that represents a service account. For example,
 -- \`my-other-app\'appspot.gserviceaccount.com\`. * \`group:{emailid}\`: An
 -- email address that represents a Google group. For example,
--- \`admins\'example.com\`. * \`domain:{domain}\`: The G Suite domain
--- (primary) that represents all the users of that domain. For example,
--- \`google.com\` or \`example.com\`.
+-- \`admins\'example.com\`. * \`deleted:user:{emailid}?uid={uniqueid}\`: An
+-- email address (plus unique identifier) representing a user that has been
+-- recently deleted. For example,
+-- \`alice\'example.com?uid=123456789012345678901\`. If the user is
+-- recovered, this value reverts to \`user:{emailid}\` and the recovered
+-- user retains the role in the binding. *
+-- \`deleted:serviceAccount:{emailid}?uid={uniqueid}\`: An email address
+-- (plus unique identifier) representing a service account that has been
+-- recently deleted. For example,
+-- \`my-other-app\'appspot.gserviceaccount.com?uid=123456789012345678901\`.
+-- If the service account is undeleted, this value reverts to
+-- \`serviceAccount:{emailid}\` and the undeleted service account retains
+-- the role in the binding. * \`deleted:group:{emailid}?uid={uniqueid}\`:
+-- An email address (plus unique identifier) representing a Google group
+-- that has been recently deleted. For example,
+-- \`admins\'example.com?uid=123456789012345678901\`. If the group is
+-- recovered, this value reverts to \`group:{emailid}\` and the recovered
+-- group retains the role in the binding. * \`domain:{domain}\`: The G
+-- Suite domain (primary) that represents all the users of that domain. For
+-- example, \`google.com\` or \`example.com\`.
 bMembers :: Lens' Binding [Text]
 bMembers
   = lens _bMembers (\ s a -> s{_bMembers = a}) .
@@ -2032,9 +2521,14 @@ bMembers
 bRole :: Lens' Binding (Maybe Text)
 bRole = lens _bRole (\ s a -> s{_bRole = a})
 
--- | The condition that is associated with this binding. NOTE: An unsatisfied
--- condition will not allow user access via current binding. Different
--- bindings, including their conditions, are examined independently.
+-- | The condition that is associated with this binding. If the condition
+-- evaluates to \`true\`, then this binding applies to the current request.
+-- If the condition evaluates to \`false\`, then this binding does not
+-- apply to the current request. However, a different role binding might
+-- grant the same role to one or more of the members in this binding. To
+-- learn which resources support conditions in their IAM policies, see the
+-- [IAM
+-- documentation](https:\/\/cloud.google.com\/iam\/help\/conditions\/resource-policies).
 bCondition :: Lens' Binding (Maybe Expr)
 bCondition
   = lens _bCondition (\ s a -> s{_bCondition = a})

--- a/gogol-cloudtasks/gen/Network/Google/CloudTasks/Types/Sum.hs
+++ b/gogol-cloudtasks/gen/Network/Google/CloudTasks/Types/Sum.hs
@@ -16,7 +16,7 @@
 --
 module Network.Google.CloudTasks.Types.Sum where
 
-import           Network.Google.Prelude hiding (Bytes)
+import Network.Google.Prelude hiding (Bytes)
 
 -- | Output only. The view specifies which subset of the Task has been
 -- returned.
@@ -164,13 +164,11 @@ instance ToJSON CreateTaskRequestResponseView where
 
 -- | The HTTP method to use for the request. The default is POST. The app\'s
 -- request handler for the task\'s target URL must be able to handle HTTP
--- requests with this http_method, otherwise the task attempt will fail
--- with error code 405 (Method Not Allowed). See [Writing a push task
--- request
+-- requests with this http_method, otherwise the task attempt fails with
+-- error code 405 (Method Not Allowed). See [Writing a push task request
 -- handler](https:\/\/cloud.google.com\/appengine\/docs\/java\/taskqueue\/push\/creating-handlers#writing_a_push_task_request_handler)
--- and the documentation for the request handlers in the language your app
--- is written in e.g. [Python Request
--- Handler](https:\/\/cloud.google.com\/appengine\/docs\/python\/tools\/webapp\/requesthandlerclass).
+-- and the App Engine documentation for your runtime on [How Requests are
+-- Handled](https:\/\/cloud.google.com\/appengine\/docs\/standard\/python3\/how-requests-are-handled).
 data AppEngineHTTPRequestHTTPMethod
     = HTTPMethodUnspecified
       -- ^ @HTTP_METHOD_UNSPECIFIED@
@@ -303,4 +301,63 @@ instance FromJSON RunTaskRequestResponseView where
     parseJSON = parseJSONText "RunTaskRequestResponseView"
 
 instance ToJSON RunTaskRequestResponseView where
+    toJSON = toJSONText
+
+-- | The HTTP method to use for the request. The default is POST.
+data HTTPRequestHTTPMethod
+    = HTTPRHTTPMHTTPMethodUnspecified
+      -- ^ @HTTP_METHOD_UNSPECIFIED@
+      -- HTTP method unspecified
+    | HTTPRHTTPMPost'
+      -- ^ @POST@
+      -- HTTP POST
+    | HTTPRHTTPMGet'
+      -- ^ @GET@
+      -- HTTP GET
+    | HTTPRHTTPMHead'
+      -- ^ @HEAD@
+      -- HTTP HEAD
+    | HTTPRHTTPMPut'
+      -- ^ @PUT@
+      -- HTTP PUT
+    | HTTPRHTTPMDelete'
+      -- ^ @DELETE@
+      -- HTTP DELETE
+    | HTTPRHTTPMPatch'
+      -- ^ @PATCH@
+      -- HTTP PATCH
+    | HTTPRHTTPMOptions
+      -- ^ @OPTIONS@
+      -- HTTP OPTIONS
+      deriving (Eq, Ord, Enum, Read, Show, Data, Typeable, Generic)
+
+instance Hashable HTTPRequestHTTPMethod
+
+instance FromHttpApiData HTTPRequestHTTPMethod where
+    parseQueryParam = \case
+        "HTTP_METHOD_UNSPECIFIED" -> Right HTTPRHTTPMHTTPMethodUnspecified
+        "POST" -> Right HTTPRHTTPMPost'
+        "GET" -> Right HTTPRHTTPMGet'
+        "HEAD" -> Right HTTPRHTTPMHead'
+        "PUT" -> Right HTTPRHTTPMPut'
+        "DELETE" -> Right HTTPRHTTPMDelete'
+        "PATCH" -> Right HTTPRHTTPMPatch'
+        "OPTIONS" -> Right HTTPRHTTPMOptions
+        x -> Left ("Unable to parse HTTPRequestHTTPMethod from: " <> x)
+
+instance ToHttpApiData HTTPRequestHTTPMethod where
+    toQueryParam = \case
+        HTTPRHTTPMHTTPMethodUnspecified -> "HTTP_METHOD_UNSPECIFIED"
+        HTTPRHTTPMPost' -> "POST"
+        HTTPRHTTPMGet' -> "GET"
+        HTTPRHTTPMHead' -> "HEAD"
+        HTTPRHTTPMPut' -> "PUT"
+        HTTPRHTTPMDelete' -> "DELETE"
+        HTTPRHTTPMPatch' -> "PATCH"
+        HTTPRHTTPMOptions -> "OPTIONS"
+
+instance FromJSON HTTPRequestHTTPMethod where
+    parseJSON = parseJSONText "HTTPRequestHTTPMethod"
+
+instance ToJSON HTTPRequestHTTPMethod where
     toJSON = toJSONText

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Get.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Get.hs
@@ -41,8 +41,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Get
     , plgCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.get@ method which the
 -- 'ProjectsLocationsGet' request conforms to.
@@ -61,12 +61,12 @@ type ProjectsLocationsGetResource =
 -- /See:/ 'projectsLocationsGet' smart constructor.
 data ProjectsLocationsGet =
   ProjectsLocationsGet'
-    { _plgXgafv          :: !(Maybe Xgafv)
+    { _plgXgafv :: !(Maybe Xgafv)
     , _plgUploadProtocol :: !(Maybe Text)
-    , _plgAccessToken    :: !(Maybe Text)
-    , _plgUploadType     :: !(Maybe Text)
-    , _plgName           :: !Text
-    , _plgCallback       :: !(Maybe Text)
+    , _plgAccessToken :: !(Maybe Text)
+    , _plgUploadType :: !(Maybe Text)
+    , _plgName :: !Text
+    , _plgCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/List.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/List.hs
@@ -44,8 +44,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.List
     , pllCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.list@ method which the
 -- 'ProjectsLocationsList' request conforms to.
@@ -69,15 +69,15 @@ type ProjectsLocationsListResource =
 -- /See:/ 'projectsLocationsList' smart constructor.
 data ProjectsLocationsList =
   ProjectsLocationsList'
-    { _pllXgafv          :: !(Maybe Xgafv)
+    { _pllXgafv :: !(Maybe Xgafv)
     , _pllUploadProtocol :: !(Maybe Text)
-    , _pllAccessToken    :: !(Maybe Text)
-    , _pllUploadType     :: !(Maybe Text)
-    , _pllName           :: !Text
-    , _pllFilter         :: !(Maybe Text)
-    , _pllPageToken      :: !(Maybe Text)
-    , _pllPageSize       :: !(Maybe (Textual Int32))
-    , _pllCallback       :: !(Maybe Text)
+    , _pllAccessToken :: !(Maybe Text)
+    , _pllUploadType :: !(Maybe Text)
+    , _pllName :: !Text
+    , _pllFilter :: !(Maybe Text)
+    , _pllPageToken :: !(Maybe Text)
+    , _pllPageSize :: !(Maybe (Textual Int32))
+    , _pllCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Create.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Create.hs
@@ -49,8 +49,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Create
     , plqcCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.create@ method which the
 -- 'ProjectsLocationsQueuesCreate' request conforms to.
@@ -78,13 +78,13 @@ type ProjectsLocationsQueuesCreateResource =
 -- /See:/ 'projectsLocationsQueuesCreate' smart constructor.
 data ProjectsLocationsQueuesCreate =
   ProjectsLocationsQueuesCreate'
-    { _plqcParent         :: !Text
-    , _plqcXgafv          :: !(Maybe Xgafv)
+    { _plqcParent :: !Text
+    , _plqcXgafv :: !(Maybe Xgafv)
     , _plqcUploadProtocol :: !(Maybe Text)
-    , _plqcAccessToken    :: !(Maybe Text)
-    , _plqcUploadType     :: !(Maybe Text)
-    , _plqcPayload        :: !Queue
-    , _plqcCallback       :: !(Maybe Text)
+    , _plqcAccessToken :: !(Maybe Text)
+    , _plqcUploadType :: !(Maybe Text)
+    , _plqcPayload :: !Queue
+    , _plqcCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Delete.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Delete.hs
@@ -47,8 +47,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Delete
     , plqdCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.delete@ method which the
 -- 'ProjectsLocationsQueuesDelete' request conforms to.
@@ -73,12 +73,12 @@ type ProjectsLocationsQueuesDeleteResource =
 -- /See:/ 'projectsLocationsQueuesDelete' smart constructor.
 data ProjectsLocationsQueuesDelete =
   ProjectsLocationsQueuesDelete'
-    { _plqdXgafv          :: !(Maybe Xgafv)
+    { _plqdXgafv :: !(Maybe Xgafv)
     , _plqdUploadProtocol :: !(Maybe Text)
-    , _plqdAccessToken    :: !(Maybe Text)
-    , _plqdUploadType     :: !(Maybe Text)
-    , _plqdName           :: !Text
-    , _plqdCallback       :: !(Maybe Text)
+    , _plqdAccessToken :: !(Maybe Text)
+    , _plqdUploadType :: !(Maybe Text)
+    , _plqdName :: !Text
+    , _plqdCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Get.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Get.hs
@@ -41,8 +41,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Get
     , plqgCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.get@ method which the
 -- 'ProjectsLocationsQueuesGet' request conforms to.
@@ -61,12 +61,12 @@ type ProjectsLocationsQueuesGetResource =
 -- /See:/ 'projectsLocationsQueuesGet' smart constructor.
 data ProjectsLocationsQueuesGet =
   ProjectsLocationsQueuesGet'
-    { _plqgXgafv          :: !(Maybe Xgafv)
+    { _plqgXgafv :: !(Maybe Xgafv)
     , _plqgUploadProtocol :: !(Maybe Text)
-    , _plqgAccessToken    :: !(Maybe Text)
-    , _plqgUploadType     :: !(Maybe Text)
-    , _plqgName           :: !Text
-    , _plqgCallback       :: !(Maybe Text)
+    , _plqgAccessToken :: !(Maybe Text)
+    , _plqgUploadType :: !(Maybe Text)
+    , _plqgName :: !Text
+    , _plqgCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/GetIAMPolicy.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/GetIAMPolicy.hs
@@ -46,8 +46,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.GetIAMPolicy
     , plqgipCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.getIamPolicy@ method which the
 -- 'ProjectsLocationsQueuesGetIAMPolicy' request conforms to.
@@ -72,13 +72,13 @@ type ProjectsLocationsQueuesGetIAMPolicyResource =
 -- /See:/ 'projectsLocationsQueuesGetIAMPolicy' smart constructor.
 data ProjectsLocationsQueuesGetIAMPolicy =
   ProjectsLocationsQueuesGetIAMPolicy'
-    { _plqgipXgafv          :: !(Maybe Xgafv)
+    { _plqgipXgafv :: !(Maybe Xgafv)
     , _plqgipUploadProtocol :: !(Maybe Text)
-    , _plqgipAccessToken    :: !(Maybe Text)
-    , _plqgipUploadType     :: !(Maybe Text)
-    , _plqgipPayload        :: !GetIAMPolicyRequest
-    , _plqgipResource       :: !Text
-    , _plqgipCallback       :: !(Maybe Text)
+    , _plqgipAccessToken :: !(Maybe Text)
+    , _plqgipUploadType :: !(Maybe Text)
+    , _plqgipPayload :: !GetIAMPolicyRequest
+    , _plqgipResource :: !Text
+    , _plqgipCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/List.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/List.hs
@@ -44,8 +44,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.List
     , plqlCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.list@ method which the
 -- 'ProjectsLocationsQueuesList' request conforms to.
@@ -69,15 +69,15 @@ type ProjectsLocationsQueuesListResource =
 -- /See:/ 'projectsLocationsQueuesList' smart constructor.
 data ProjectsLocationsQueuesList =
   ProjectsLocationsQueuesList'
-    { _plqlParent         :: !Text
-    , _plqlXgafv          :: !(Maybe Xgafv)
+    { _plqlParent :: !Text
+    , _plqlXgafv :: !(Maybe Xgafv)
     , _plqlUploadProtocol :: !(Maybe Text)
-    , _plqlAccessToken    :: !(Maybe Text)
-    , _plqlUploadType     :: !(Maybe Text)
-    , _plqlFilter         :: !(Maybe Text)
-    , _plqlPageToken      :: !(Maybe Text)
-    , _plqlPageSize       :: !(Maybe (Textual Int32))
-    , _plqlCallback       :: !(Maybe Text)
+    , _plqlAccessToken :: !(Maybe Text)
+    , _plqlUploadType :: !(Maybe Text)
+    , _plqlFilter :: !(Maybe Text)
+    , _plqlPageToken :: !(Maybe Text)
+    , _plqlPageSize :: !(Maybe (Textual Int32))
+    , _plqlCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Patch.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Patch.hs
@@ -51,8 +51,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Patch
     , plqpCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.patch@ method which the
 -- 'ProjectsLocationsQueuesPatch' request conforms to.
@@ -81,14 +81,14 @@ type ProjectsLocationsQueuesPatchResource =
 -- /See:/ 'projectsLocationsQueuesPatch' smart constructor.
 data ProjectsLocationsQueuesPatch =
   ProjectsLocationsQueuesPatch'
-    { _plqpXgafv          :: !(Maybe Xgafv)
+    { _plqpXgafv :: !(Maybe Xgafv)
     , _plqpUploadProtocol :: !(Maybe Text)
-    , _plqpUpdateMask     :: !(Maybe GFieldMask)
-    , _plqpAccessToken    :: !(Maybe Text)
-    , _plqpUploadType     :: !(Maybe Text)
-    , _plqpPayload        :: !Queue
-    , _plqpName           :: !Text
-    , _plqpCallback       :: !(Maybe Text)
+    , _plqpUpdateMask :: !(Maybe GFieldMask)
+    , _plqpAccessToken :: !(Maybe Text)
+    , _plqpUploadType :: !(Maybe Text)
+    , _plqpPayload :: !Queue
+    , _plqpName :: !Text
+    , _plqpCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Pause.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Pause.hs
@@ -45,8 +45,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Pause
     , proCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.pause@ method which the
 -- 'ProjectsLocationsQueuesPause' request conforms to.
@@ -70,13 +70,13 @@ type ProjectsLocationsQueuesPauseResource =
 -- /See:/ 'projectsLocationsQueuesPause' smart constructor.
 data ProjectsLocationsQueuesPause =
   ProjectsLocationsQueuesPause'
-    { _proXgafv          :: !(Maybe Xgafv)
+    { _proXgafv :: !(Maybe Xgafv)
     , _proUploadProtocol :: !(Maybe Text)
-    , _proAccessToken    :: !(Maybe Text)
-    , _proUploadType     :: !(Maybe Text)
-    , _proPayload        :: !PauseQueueRequest
-    , _proName           :: !Text
-    , _proCallback       :: !(Maybe Text)
+    , _proAccessToken :: !(Maybe Text)
+    , _proUploadType :: !(Maybe Text)
+    , _proPayload :: !PauseQueueRequest
+    , _proName :: !Text
+    , _proCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Purge.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Purge.hs
@@ -45,8 +45,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Purge
     , pCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.purge@ method which the
 -- 'ProjectsLocationsQueuesPurge' request conforms to.
@@ -70,13 +70,13 @@ type ProjectsLocationsQueuesPurgeResource =
 -- /See:/ 'projectsLocationsQueuesPurge' smart constructor.
 data ProjectsLocationsQueuesPurge =
   ProjectsLocationsQueuesPurge'
-    { _pXgafv          :: !(Maybe Xgafv)
+    { _pXgafv :: !(Maybe Xgafv)
     , _pUploadProtocol :: !(Maybe Text)
-    , _pAccessToken    :: !(Maybe Text)
-    , _pUploadType     :: !(Maybe Text)
-    , _pPayload        :: !PurgeQueueRequest
-    , _pName           :: !Text
-    , _pCallback       :: !(Maybe Text)
+    , _pAccessToken :: !(Maybe Text)
+    , _pUploadType :: !(Maybe Text)
+    , _pPayload :: !PurgeQueueRequest
+    , _pName :: !Text
+    , _pCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Resume.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Resume.hs
@@ -48,8 +48,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Resume
     , plqrCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.resume@ method which the
 -- 'ProjectsLocationsQueuesResume' request conforms to.
@@ -76,13 +76,13 @@ type ProjectsLocationsQueuesResumeResource =
 -- /See:/ 'projectsLocationsQueuesResume' smart constructor.
 data ProjectsLocationsQueuesResume =
   ProjectsLocationsQueuesResume'
-    { _plqrXgafv          :: !(Maybe Xgafv)
+    { _plqrXgafv :: !(Maybe Xgafv)
     , _plqrUploadProtocol :: !(Maybe Text)
-    , _plqrAccessToken    :: !(Maybe Text)
-    , _plqrUploadType     :: !(Maybe Text)
-    , _plqrPayload        :: !ResumeQueueRequest
-    , _plqrName           :: !Text
-    , _plqrCallback       :: !(Maybe Text)
+    , _plqrAccessToken :: !(Maybe Text)
+    , _plqrUploadType :: !(Maybe Text)
+    , _plqrPayload :: !ResumeQueueRequest
+    , _plqrName :: !Text
+    , _plqrCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/SetIAMPolicy.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/SetIAMPolicy.hs
@@ -47,8 +47,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.SetIAMPolicy
     , plqsipCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.setIamPolicy@ method which the
 -- 'ProjectsLocationsQueuesSetIAMPolicy' request conforms to.
@@ -74,13 +74,13 @@ type ProjectsLocationsQueuesSetIAMPolicyResource =
 -- /See:/ 'projectsLocationsQueuesSetIAMPolicy' smart constructor.
 data ProjectsLocationsQueuesSetIAMPolicy =
   ProjectsLocationsQueuesSetIAMPolicy'
-    { _plqsipXgafv          :: !(Maybe Xgafv)
+    { _plqsipXgafv :: !(Maybe Xgafv)
     , _plqsipUploadProtocol :: !(Maybe Text)
-    , _plqsipAccessToken    :: !(Maybe Text)
-    , _plqsipUploadType     :: !(Maybe Text)
-    , _plqsipPayload        :: !SetIAMPolicyRequest
-    , _plqsipResource       :: !Text
-    , _plqsipCallback       :: !(Maybe Text)
+    , _plqsipAccessToken :: !(Maybe Text)
+    , _plqsipUploadType :: !(Maybe Text)
+    , _plqsipPayload :: !SetIAMPolicyRequest
+    , _plqsipResource :: !Text
+    , _plqsipCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/Create.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/Create.hs
@@ -21,8 +21,8 @@
 -- Portability : non-portable (GHC extensions)
 --
 -- Creates a task and adds it to a queue. Tasks cannot be updated after
--- creation; there is no UpdateTask command. * For App Engine queues, the
--- maximum task size is 100KB.
+-- creation; there is no UpdateTask command. * The maximum task size is
+-- 100KB.
 --
 -- /See:/ <https://cloud.google.com/tasks/ Cloud Tasks API Reference> for @cloudtasks.projects.locations.queues.tasks.create@.
 module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Create
@@ -44,8 +44,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Create
     , plqtcCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.tasks.create@ method which the
 -- 'ProjectsLocationsQueuesTasksCreate' request conforms to.
@@ -63,19 +63,19 @@ type ProjectsLocationsQueuesTasksCreateResource =
                          Post '[JSON] Task
 
 -- | Creates a task and adds it to a queue. Tasks cannot be updated after
--- creation; there is no UpdateTask command. * For App Engine queues, the
--- maximum task size is 100KB.
+-- creation; there is no UpdateTask command. * The maximum task size is
+-- 100KB.
 --
 -- /See:/ 'projectsLocationsQueuesTasksCreate' smart constructor.
 data ProjectsLocationsQueuesTasksCreate =
   ProjectsLocationsQueuesTasksCreate'
-    { _plqtcParent         :: !Text
-    , _plqtcXgafv          :: !(Maybe Xgafv)
+    { _plqtcParent :: !Text
+    , _plqtcXgafv :: !(Maybe Xgafv)
     , _plqtcUploadProtocol :: !(Maybe Text)
-    , _plqtcAccessToken    :: !(Maybe Text)
-    , _plqtcUploadType     :: !(Maybe Text)
-    , _plqtcPayload        :: !CreateTaskRequest
-    , _plqtcCallback       :: !(Maybe Text)
+    , _plqtcAccessToken :: !(Maybe Text)
+    , _plqtcUploadType :: !(Maybe Text)
+    , _plqtcPayload :: !CreateTaskRequest
+    , _plqtcCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/Delete.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/Delete.hs
@@ -43,8 +43,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Delete
     , plqtdCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.tasks.delete@ method which the
 -- 'ProjectsLocationsQueuesTasksDelete' request conforms to.
@@ -65,12 +65,12 @@ type ProjectsLocationsQueuesTasksDeleteResource =
 -- /See:/ 'projectsLocationsQueuesTasksDelete' smart constructor.
 data ProjectsLocationsQueuesTasksDelete =
   ProjectsLocationsQueuesTasksDelete'
-    { _plqtdXgafv          :: !(Maybe Xgafv)
+    { _plqtdXgafv :: !(Maybe Xgafv)
     , _plqtdUploadProtocol :: !(Maybe Text)
-    , _plqtdAccessToken    :: !(Maybe Text)
-    , _plqtdUploadType     :: !(Maybe Text)
-    , _plqtdName           :: !Text
-    , _plqtdCallback       :: !(Maybe Text)
+    , _plqtdAccessToken :: !(Maybe Text)
+    , _plqtdUploadType :: !(Maybe Text)
+    , _plqtdName :: !Text
+    , _plqtdCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/Get.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/Get.hs
@@ -42,8 +42,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Get
     , plqtgCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.tasks.get@ method which the
 -- 'ProjectsLocationsQueuesTasksGet' request conforms to.
@@ -63,13 +63,13 @@ type ProjectsLocationsQueuesTasksGetResource =
 -- /See:/ 'projectsLocationsQueuesTasksGet' smart constructor.
 data ProjectsLocationsQueuesTasksGet =
   ProjectsLocationsQueuesTasksGet'
-    { _plqtgXgafv          :: !(Maybe Xgafv)
+    { _plqtgXgafv :: !(Maybe Xgafv)
     , _plqtgUploadProtocol :: !(Maybe Text)
-    , _plqtgAccessToken    :: !(Maybe Text)
-    , _plqtgUploadType     :: !(Maybe Text)
-    , _plqtgResponseView   :: !(Maybe Text)
-    , _plqtgName           :: !Text
-    , _plqtgCallback       :: !(Maybe Text)
+    , _plqtgAccessToken :: !(Maybe Text)
+    , _plqtgUploadType :: !(Maybe Text)
+    , _plqtgResponseView :: !(Maybe Text)
+    , _plqtgName :: !Text
+    , _plqtgCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/List.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/List.hs
@@ -47,8 +47,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.List
     , plqtlCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.tasks.list@ method which the
 -- 'ProjectsLocationsQueuesTasksList' request conforms to.
@@ -75,15 +75,15 @@ type ProjectsLocationsQueuesTasksListResource =
 -- /See:/ 'projectsLocationsQueuesTasksList' smart constructor.
 data ProjectsLocationsQueuesTasksList =
   ProjectsLocationsQueuesTasksList'
-    { _plqtlParent         :: !Text
-    , _plqtlXgafv          :: !(Maybe Xgafv)
+    { _plqtlParent :: !Text
+    , _plqtlXgafv :: !(Maybe Xgafv)
     , _plqtlUploadProtocol :: !(Maybe Text)
-    , _plqtlAccessToken    :: !(Maybe Text)
-    , _plqtlUploadType     :: !(Maybe Text)
-    , _plqtlResponseView   :: !(Maybe Text)
-    , _plqtlPageToken      :: !(Maybe Text)
-    , _plqtlPageSize       :: !(Maybe (Textual Int32))
-    , _plqtlCallback       :: !(Maybe Text)
+    , _plqtlAccessToken :: !(Maybe Text)
+    , _plqtlUploadType :: !(Maybe Text)
+    , _plqtlResponseView :: !(Maybe Text)
+    , _plqtlPageToken :: !(Maybe Text)
+    , _plqtlPageSize :: !(Maybe (Textual Int32))
+    , _plqtlCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 
@@ -177,11 +177,10 @@ plqtlPageToken
   = lens _plqtlPageToken
       (\ s a -> s{_plqtlPageToken = a})
 
--- | Requested page size. Fewer tasks than requested might be returned. The
--- maximum page size is 1000. If unspecified, the page size will be the
--- maximum. Fewer tasks than requested might be returned, even if more
--- tasks exist; use next_page_token in the response to determine if more
--- tasks exist.
+-- | Maximum page size. Fewer tasks than requested might be returned, even if
+-- more tasks exist; use next_page_token in the response to determine if
+-- more tasks exist. The maximum page size is 1000. If unspecified, the
+-- page size will be the maximum.
 plqtlPageSize :: Lens' ProjectsLocationsQueuesTasksList (Maybe Int32)
 plqtlPageSize
   = lens _plqtlPageSize

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/Run.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/Tasks/Run.hs
@@ -54,8 +54,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.Tasks.Run
     , plqtrCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.tasks.run@ method which the
 -- 'ProjectsLocationsQueuesTasksRun' request conforms to.
@@ -87,13 +87,13 @@ type ProjectsLocationsQueuesTasksRunResource =
 -- /See:/ 'projectsLocationsQueuesTasksRun' smart constructor.
 data ProjectsLocationsQueuesTasksRun =
   ProjectsLocationsQueuesTasksRun'
-    { _plqtrXgafv          :: !(Maybe Xgafv)
+    { _plqtrXgafv :: !(Maybe Xgafv)
     , _plqtrUploadProtocol :: !(Maybe Text)
-    , _plqtrAccessToken    :: !(Maybe Text)
-    , _plqtrUploadType     :: !(Maybe Text)
-    , _plqtrPayload        :: !RunTaskRequest
-    , _plqtrName           :: !Text
-    , _plqtrCallback       :: !(Maybe Text)
+    , _plqtrAccessToken :: !(Maybe Text)
+    , _plqtrUploadType :: !(Maybe Text)
+    , _plqtrPayload :: !RunTaskRequest
+    , _plqtrName :: !Text
+    , _plqtrCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 

--- a/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/TestIAMPermissions.hs
+++ b/gogol-cloudtasks/gen/Network/Google/Resource/CloudTasks/Projects/Locations/Queues/TestIAMPermissions.hs
@@ -46,8 +46,8 @@ module Network.Google.Resource.CloudTasks.Projects.Locations.Queues.TestIAMPermi
     , plqtipCallback
     ) where
 
-import           Network.Google.CloudTasks.Types
-import           Network.Google.Prelude
+import Network.Google.CloudTasks.Types
+import Network.Google.Prelude
 
 -- | A resource alias for @cloudtasks.projects.locations.queues.testIamPermissions@ method which the
 -- 'ProjectsLocationsQueuesTestIAMPermissions' request conforms to.
@@ -73,13 +73,13 @@ type ProjectsLocationsQueuesTestIAMPermissionsResource
 -- /See:/ 'projectsLocationsQueuesTestIAMPermissions' smart constructor.
 data ProjectsLocationsQueuesTestIAMPermissions =
   ProjectsLocationsQueuesTestIAMPermissions'
-    { _plqtipXgafv          :: !(Maybe Xgafv)
+    { _plqtipXgafv :: !(Maybe Xgafv)
     , _plqtipUploadProtocol :: !(Maybe Text)
-    , _plqtipAccessToken    :: !(Maybe Text)
-    , _plqtipUploadType     :: !(Maybe Text)
-    , _plqtipPayload        :: !TestIAMPermissionsRequest
-    , _plqtipResource       :: !Text
-    , _plqtipCallback       :: !(Maybe Text)
+    , _plqtipAccessToken :: !(Maybe Text)
+    , _plqtipUploadType :: !(Maybe Text)
+    , _plqtipPayload :: !TestIAMPermissionsRequest
+    , _plqtipResource :: !Text
+    , _plqtipCallback :: !(Maybe Text)
     }
   deriving (Eq, Show, Data, Typeable, Generic)
 


### PR DESCRIPTION
There is an import object field (HttpRequest) missing in the current definition of the Cloud Tasks API [1]. This PR fetches an updated version of the API definition that includes the object's definition.

[1] - https://cloud.google.com/tasks/docs/reference/rest/v2/projects.locations.queues.tasks#HttpRequest