### PR TITLE
Fix generation

### DIFF
--- a/gen/annex/youtube.json
+++ b/gen/annex/youtube.json
@@ -62,17 +62,6 @@
                     }
                 }
             }
-        },
-        "sponsors": {
-            "methods": {
-                "list": {
-                    "parameters": {
-                        "filter": {
-                            "default": "newest"
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/gen/src/Gen/AST/Solve.hs
+++ b/gen/src/Gen/AST/Solve.hs
@@ -201,7 +201,7 @@ acronymPrefixes (global -> (renameSpecial -> g)) =
 
     full = CI.mk g
 
-    zs = zipWith (\n x -> Text.snoc x (head (show n))) ([1..] :: [Int]) xs
+    zs = liftA2 (\n x -> Text.snoc x (head (show n))) ([1..] :: [Int]) xs
 
     xs = catMaybes [r1, r2, r3, r4, r5, r6]
     ys = catMaybes [r1, r2, r3, r4, r6]

--- a/gen/src/Gen/Types.hs
+++ b/gen/src/Gen/Types.hs
@@ -101,6 +101,7 @@ makeClassy ''Versions
 
 data Release
     = Sandbox
+    | Dev     (Maybe Int) (Maybe Char)
     | Alpha   (Maybe Int) (Maybe Char)
     | Beta    (Maybe Int) (Maybe Char)
       deriving (Eq, Ord, Show)
@@ -123,7 +124,7 @@ parseVersion x = first (mappend (Text.unpack x) . mappend " -> ") $
     empty'  = ModelVersion 0 <$> (alpha <|> beta <|> exp')
     version = ModelVersion
         <$> number
-        <*> (alpha <|> beta <|> sandbox <|> pure Nothing)
+        <*> (alpha <|> beta <|> sandbox <|> dev <|> pure Nothing)
 
     preface = A.takeWhile (/= '_') *> void (A.char '_') <|> pure ()
 
@@ -133,6 +134,10 @@ parseVersion x = first (mappend (Text.unpack x) . mappend " -> ") $
       p <- A.many1 A.digit
       return (read (n ++ "." ++ p) :: Double)
     number  = A.takeWhile  (/= 'v') *> A.char 'v' *> (protoVersionParser <|> A.double)
+
+    dev = A.string "dev"
+         *> (Dev <$> optional A.decimal <*> optional A.letter)
+        <&> Just
 
     alpha = A.string "alpha"
          *> (Alpha <$> optional A.decimal <*> optional A.letter)

--- a/gen/src/Gen/Types/Schema.hs
+++ b/gen/src/Gen/Types/Schema.hs
@@ -284,7 +284,7 @@ instance HasInfo a => HasInfo (Param a) where
 data MediaUpload = MediaUpload
     { _muAccept        :: [Text]
     , _muMaxSize       :: Maybe Text
-    , _muResumablePath :: Text
+    , _muResumablePath :: Maybe Text
     , _muSimplePath    :: Text
     } deriving (Eq, Show)
 
@@ -292,8 +292,9 @@ instance FromJSON MediaUpload where
     parseJSON = withObject "mediaUpload" $ \o -> MediaUpload
          <$>  o .:  "accept"
          <*>  o .:? "maxSize"
-         <*> (o .:  "protocols" >>= (.: "resumable") >>= (.: "path"))
+         <*> (o .:  "protocols" >>= (.:? "resumable") >>= maybe (pure Nothing) (.: "path"))
          <*> (o .:  "protocols" >>= (.: "simple")    >>= (.: "path"))
+
 
 data Method a = Method
     { _mId                    :: Global


### PR DESCRIPTION
Hi,

I've fixed a couple of issues in the 2 commits so far. I'm mostly cargo culting the fixes so it could be the wrong solution, but it seems to make it pass.

The next issue I don't know how to fix:

```
[206/215] model:videointelligence
 -> Reading /home/bananan/dead/gogol/gen/annex/videointelligence.json
 -> Reading /home/bananan/dead/gogol/gen/model/videointelligence/v1p3beta1/videointelligence-api.json
 -> Successfully parsed 'videointelligence' API definition.
gogol-gen: Error prefixing: GoogleCloudVideointelligenceV1p1beta1_DetectedLandmark
  Fields: ["confidence","point","name"]
  Matches: 
gcvvdl => Just (fromList ["confidence","point","name"])
g => Just (fromList ["feature","alternatives","languageCode","bottom","annotationProgress","rotatedBoundingBox","startTime","categoryEntities","timeOffset","startTimeOffset","inputUri","left","progressPercent","frames","confidence","updateTime","endTimeOffset","version","annotationResults","words","segments","x","right","top","segment","entity","transcript","vertices","y"])
goo => Just (fromList ["tracks","shotAnnotations","languageCode","bottom","annotationProgress","shotLabelAnnotations","startTime","timeOffset","startTimeOffset","error","inputUri","left","shotPresenceLabelAnnotations","frames","objectAnnotations","confidence","endTimeOffset","frameLabelAnnotations","version","endTime","annotationResults","speechTranscriptions","segments","x","logoRecognitionAnnotations","right","segmentPresenceLabelAnnotations","top","segment","entity","word","normalizedBoundingBox","description","entityId","vertices","segmentLabelAnnotations","speakerTag","explicitAnnotation","y","textAnnotations"])
gcvvdlc => Just (fromList ["confidence","point","name"])
gg => Just (fromList ["languageCode","text","timeOffset","confidence","version","segments","description","entityId"])
gooo => Just (fromList ["tracks","languageCode","startTime","timeOffset","frames","confidence","version","endTime","segments","pornographyLikelihood","entity","word","description","entityId","speakerTag"])
gcvvdl1 => Just (fromList ["confidence","point","name"])
g2 => Just (fromList ["confidence","words","transcript"])
goo3 => Just (fromList ["timeOffset","confidence"])
Makefile:22: recipe for target 'gen' failed
make: *** [gen] Error 1
```

Any ideas?