### PR TITLE
Upgrade gen to lts-16.31

### DIFF
--- a/gen/gogol-gen.cabal
+++ b/gen/gogol-gen.cabal
@@ -50,10 +50,12 @@ executable gogol-gen
         , bifunctors
         , bytestring
         , case-insensitive
+        , directory
         , directory-tree
         , doclayout
         , ede
         , errors           >= 2.1.2
+        , filepath
         , formatting
         , hashable
         , haskell-src-exts == 1.23.1
@@ -64,8 +66,6 @@ executable gogol-gen
         , pandoc
         , parsec
         , semigroups
-        , system-fileio
-        , system-filepath
         , text
         , text-icu
         , text-manipulate

--- a/gen/gogol-gen.cabal
+++ b/gen/gogol-gen.cabal
@@ -51,12 +51,13 @@ executable gogol-gen
         , bytestring
         , case-insensitive
         , directory-tree
+        , doclayout
         , ede
         , errors           >= 2.1.2
         , formatting
         , hashable
-        , haskell-src-exts == 1.20.3
-        , hindent          == 5.2.7
+        , haskell-src-exts == 1.23.1
+        , hindent          == 5.3.2
         , lens
         , mtl
         , optparse-applicative

--- a/gen/src/Gen/AST/Flatten.hs
+++ b/gen/src/Gen/AST/Flatten.hs
@@ -25,7 +25,6 @@ import           Control.Monad.Except
 import qualified Data.HashMap.Strict  as Map
 import qualified Data.HashSet         as Set
 import           Data.Maybe
-import           Data.Semigroup       ((<>))
 import           Gen.Formatting
 import           Gen.Types
 import           Prelude              hiding (sum)

--- a/gen/src/Gen/AST/Render.hs
+++ b/gen/src/Gen/AST/Render.hs
@@ -26,7 +26,6 @@ import qualified Data.ByteString.Lazy.Builder as LBB
 import           Data.Char                    (isSpace)
 import qualified Data.HashMap.Strict          as Map
 import           Data.Maybe
-import           Data.Semigroup               ((<>))
 import           Data.String
 import qualified Data.Text.Lazy               as LText
 import qualified Data.Text.Lazy.Encoding      as LText

--- a/gen/src/Gen/AST/Solve.hs
+++ b/gen/src/Gen/AST/Solve.hs
@@ -30,7 +30,6 @@ import qualified Data.HashMap.Strict  as Map
 import qualified Data.HashSet         as Set
 import           Data.List            (intersect)
 import           Data.Maybe
-import           Data.Semigroup       ((<>))
 import           Data.Text            (Text)
 import qualified Data.Text            as Text
 import           Data.Text.Manipulate

--- a/gen/src/Gen/IO.hs
+++ b/gen/src/Gen/IO.hs
@@ -82,8 +82,9 @@ createDir d = do
 copyDir :: MonadIO m => Path -> Path -> ExceptT Error m ()
 copyDir src dst = io (Dir.listDirectory src >>= mapM_ copy)
   where
-    copy f = do
-        let p = dst </> takeFileName f
+    copy filename = do
+        let f = src </> filename
+            p = dst </> filename
         fprint (" -> Copying " % path % " to " % path % "\n") f (takeDirectory p)
         Dir.copyFile f p
 

--- a/gen/src/Gen/IO.hs
+++ b/gen/src/Gen/IO.hs
@@ -24,7 +24,7 @@ import           Gen.Types
 
 import           System.IO
 
-import           UnexceptionalIO           (fromIO, runUIO)
+import qualified UnexceptionalIO           as UIO
 
 import qualified Data.Text                 as Text
 import qualified Data.Text.Lazy            as LText
@@ -36,7 +36,7 @@ run :: ExceptT Error IO a -> IO a
 run = runScript . fmapLT (Text.pack . LText.unpack)
 
 io :: MonadIO m => IO a -> ExceptT Error m a
-io = ExceptT . fmap (first (LText.pack . show)) . liftIO . runUIO . fromIO
+io = ExceptT . fmap (first (LText.pack . show)) . liftIO . UIO.run . UIO.fromIO
 
 title :: MonadIO m => Format (ExceptT Error m ()) a -> a
 title m = runFormat m (io . LText.putStrLn . toLazyText)

--- a/gen/src/Gen/Syntax.hs
+++ b/gen/src/Gen/Syntax.hs
@@ -17,7 +17,6 @@ import           Data.Foldable                (foldl', foldr')
 import qualified Data.HashMap.Strict          as Map
 import           Data.List                    (delete, nub)
 import           Data.Maybe
-import           Data.Semigroup               ((<>))
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
 import           Data.Text.Manipulate

--- a/gen/src/Gen/Types.hs
+++ b/gen/src/Gen/Types.hs
@@ -168,8 +168,7 @@ instance Ord Model where
 modelFromPath :: Path -> Model
 modelFromPath x = Model n p v x
   where
-    n = Text.init
-      . Text.intercalate "/"
+    n = Text.intercalate "/"
       . drop 1
       . dropWhile (/= "model")
       $ Text.split (== '/') p

--- a/gen/src/Gen/Types.hs
+++ b/gen/src/Gen/Types.hs
@@ -51,14 +51,13 @@ import qualified Data.HashSet               as Set
 import           Data.List                  (sort)
 import           Data.Maybe
 import           Data.Ord
-import           Data.Semigroup             ((<>))
 import           Data.String
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
 import qualified Data.Text.Lazy             as LText
 import qualified Data.Text.Lazy.Builder     as Build
 import           Data.Text.Manipulate
-import qualified Filesystem.Path.CurrentOS  as Path
+import qualified System.FilePath            as Path
 import           Formatting
 import           Gen.Orphans                ()
 import           Gen.Text
@@ -173,8 +172,8 @@ modelFromPath x = Model n p v x
       . dropWhile (/= "model")
       $ Text.split (== '/') p
 
-    p = toTextIgnore (Path.parent (Path.parent x))
-    v = either error id $ parseVersion (toTextIgnore (Path.dirname x))
+    p = toTextIgnore (Path.takeDirectory (Path.takeDirectory x))
+    v = either error id $ parseVersion (toTextIgnore (Path.takeBaseName (Path.takeDirectory x)))
 
 data Templates = Templates
     { cabalTemplate  :: Template
@@ -231,7 +230,7 @@ otherModules :: Library -> [NS]
 otherModules s = sort [prodNS s, sumNS s]
 
 toTextIgnore :: Path -> Text
-toTextIgnore = either id id . Path.toText
+toTextIgnore = Text.pack
 
 data Library = Library
     { _lVersions :: Versions

--- a/gen/src/Gen/Types/Help.hs
+++ b/gen/src/Gen/Types/Help.hs
@@ -22,7 +22,7 @@ import           Data.Text          (Text)
 import qualified System.IO.Unsafe   as Unsafe
 
 import           Text.Pandoc        as Pandoc
-import           Text.Pandoc.Pretty
+import           Text.DocLayout
 
 import qualified Data.Text          as Text
 

--- a/gen/src/Gen/Types/Schema.hs
+++ b/gen/src/Gen/Types/Schema.hs
@@ -34,7 +34,6 @@ import           Data.Aeson.Types     (Parser)
 import           Data.Function        (on)
 import qualified Data.HashMap.Strict  as Map
 import           Data.Maybe
-import           Data.Semigroup       ((<>))
 import           Data.Text            (Text)
 import qualified Data.Text            as Text
 import           Data.Text.Manipulate

--- a/gen/src/Main.hs
+++ b/gen/src/Main.hs
@@ -18,11 +18,10 @@ import           Control.Error
 import           Control.Lens              hiding ((<.>))
 import           Control.Monad.State
 import           Data.List                 (nub, sort)
-import           Data.Monoid               ((<>))
 import           Data.String
 import qualified Data.Text                 as Text
-import qualified Filesystem                as FS
-import           Filesystem.Path.CurrentOS
+import qualified System.Directory          as Dir
+import           System.FilePath
 import           Gen.AST
 import           Gen.Formatting
 import           Gen.IO
@@ -94,7 +93,7 @@ parser = Opt
              ))
 
 isPath :: ReadM Path
-isPath = eitherReader (Right . fromText . Text.dropWhileEnd (== '/') . fromString)
+isPath = eitherReader (Right . Text.unpack . Text.dropWhileEnd (== '/') . fromString)
 
 version :: ReadM (Version v)
 version = eitherReader (Right . Version . Text.pack)
@@ -116,7 +115,7 @@ validate o = flip execStateT o $ do
     check l = gets (view l) >>= canon >>= assign l
 
     canon :: MonadIO m => Path -> m Path
-    canon = liftIO . FS.canonicalizePath
+    canon = liftIO . Dir.canonicalizePath
 
 main :: IO ()
 main = do
@@ -150,7 +149,7 @@ main = do
             title ("[" % int % "/" % int % "] model:" % stext)
                   (n :: Int) i modelName
 
-            let anx = _optAnnexes </> fromText modelName <.> "json"
+            let anx = _optAnnexes </> Text.unpack modelName <.> "json"
             p <- isFile anx
             if not p
                then say ("Skipping '" % stext % "' due to missing annex configuration.")

--- a/gen/stack.yaml
+++ b/gen/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.19
+resolver: lts-16.31
 
 nix:
   enable: false
@@ -9,12 +9,10 @@ flags: {}
 
 extra-deps:
   - text-regex-replace-0.1.1.3
-  - ede-0.2.9
-  - unexceptionalio-0.3.0
-  - github: chrisdone/hindent
-    size: 51114
-    commit: ad0c2a9f8755d37f09b356ab7e45a4e49bcda0b3
-    sha256: 19954fc7dff3d008d9c7688d1c571999c1869f86e5c115aef8b28c2ae622972f
+  - ede-0.3.2.0
+  - prettyprinter-1.7.0 # for ede-0.3.2.0
+  - unexceptionalio-0.5.1
+  - hindent-5.3.2
 
 packages:
   - "."

--- a/gen/stack.yaml.lock
+++ b/gen/stack.yaml.lock
@@ -12,38 +12,36 @@ packages:
   original:
     hackage: text-regex-replace-0.1.1.3
 - completed:
-    hackage: ede-0.2.9@sha256:062198b65a661f015bff53c15d53d0b63eac547d44b09d96b7fb8d27752dfc79,3561
+    hackage: ede-0.3.2.0@sha256:26796d2dfa0979b6ec532dcb113196a1d63edde5553bd019f8d05b52cc966b1a,3790
     pantry-tree:
-      size: 5392
-      sha256: ee8d76f8f1ca483f29233498833c7159774efc3c0cb14027703cefac79c41315
+      size: 5398
+      sha256: bd0dbdf4a68c9253417b8201b23c8b62c3d62dd253583e8cd6551f7d4e641961
   original:
-    hackage: ede-0.2.9
+    hackage: ede-0.3.2.0
 - completed:
-    hackage: unexceptionalio-0.3.0@sha256:cd2d74906d336c0a0b827c935d31c39a8504c4414ffc4ab30ccbe22d0ba0cf69,1126
+    hackage: prettyprinter-1.7.0@sha256:6a9569e21fa61163a7f066d23d701e23e917893e8f39733d6e617ec72787ae5f,6007
     pantry-tree:
-      size: 217
-      sha256: 810f5bb08802115d17848c2a8233f95b16f51922edf6850aa663fc1c4067f38a
+      size: 3194
+      sha256: d22f820a1f63497f7fd7e1f04b7d356d92de35582258f6ad55428c88b09e63ff
   original:
-    hackage: unexceptionalio-0.3.0
+    hackage: prettyprinter-1.7.0
 - completed:
-    size: 51114
-    url: https://github.com/chrisdone/hindent/archive/ad0c2a9f8755d37f09b356ab7e45a4e49bcda0b3.tar.gz
-    cabal-file:
-      size: 3452
-      sha256: f3243ef357ed5464c6a5b6f38cbb73a30ec170d1ed0c7beb16c05f5f0ad61833
-    name: hindent
-    version: 5.2.7
-    sha256: 19954fc7dff3d008d9c7688d1c571999c1869f86e5c115aef8b28c2ae622972f
+    hackage: unexceptionalio-0.5.1@sha256:dfa3da738047ea55825be916559083fe3f0460ec699b3b10b7337edece7f43b3,1721
     pantry-tree:
-      size: 1808
-      sha256: 25b9067b3429d448130aa1963527a8442a3f78f9198dc2a0c9b77616d2ede801
+      size: 273
+      sha256: efb406a2a61b558b72dcbd6fb127a77d0cb3b6a72a11fc31cd85be9b079ed98f
   original:
-    size: 51114
-    url: https://github.com/chrisdone/hindent/archive/ad0c2a9f8755d37f09b356ab7e45a4e49bcda0b3.tar.gz
-    sha256: 19954fc7dff3d008d9c7688d1c571999c1869f86e5c115aef8b28c2ae622972f
+    hackage: unexceptionalio-0.5.1
+- completed:
+    hackage: hindent-5.3.2@sha256:070a3622d13e6f0c44d8d189df8f780f61d0b813435a902925ef6d9386b42260,3610
+    pantry-tree:
+      size: 1027
+      sha256: 36f9c65bbe71c49741c20839606494dacd70c04e0e70649f1da0978aeaf5f77a
+  original:
+    hackage: hindent-5.3.2
 snapshots:
 - completed:
-    size: 498155
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/19.yaml
-    sha256: b9367a80d4393d02e58a46b8a9fdfbd7bc19f59c0c2bbf90034ba15cf52cf213
-  original: lts-13.19
+    size: 534126
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
+    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
+  original: lts-16.31


### PR DESCRIPTION
I had a hard time running gen, because the needed ghc was not in my nixpkgs anymore. I had issues with the very next version of ghc (darwin issues, and finding working dependency resolution), so I bumped it up to lts-16.31 (ghc 8.8.3).

Outstanding changes are:
- Add a dependency to `doclayout`, which is an extracted part of pandoc we are using
- Bump a lot of things
- Replace the `system-fileio` and `system-filepath` dependencies, because they are deprecated, and failed in a very weird way on my machine (`canonicalizePath` failing of `..`)

Note: ideally, I would rerun the generation on the same input and check it's unchanged, but I'm sadly unable to get `stylish-haskell` to run on the bigger files, so I could not compare.