### PR TITLE
Add more reserved names to fix build with new models

### DIFF
--- a/gen/src/Gen/Text.hs
+++ b/gen/src/Gen/Text.hs
@@ -113,7 +113,7 @@ dot x = x == '.'
 
 renameReserved :: Text -> Text
 renameReserved x
-    | x `Set.member` xs = x <> "'"
+    | x `Set.member` xs = renameReserved(x <> "'")
     | otherwise         = x
   where
     xs = Set.fromList $
@@ -149,6 +149,9 @@ renameReserved x
         , "Right"
         , "Request"
         , "Enum"
+        , "Secure"
+        , "DateTime"
+        , "DateTime'"
         ] ++ map Text.pack (reservedNames haskellDef)
 
 camelAcronym :: Text -> Text


### PR DESCRIPTION
Hi there!

I noticed that, while the regeneration now works, the result doesn't build for all packages.

Here is a fix!

----- 

The `Secure` and `DateTime` are now appearing in the api, but they are (as well
as `DateTime'`) already used in `Network.Gogol.Prelude`. Adding them to the list
of reserved names fixes the build.

On top of that, this commits ensures that the named picked by `renamedReserved`
is not itself reverved (so that `DateTime` is changed to `DateTime''`).