### PR TITLE
Gen: Upgrade to lts-17.12 

### DIFF
--- a/gen/gogol-gen.cabal
+++ b/gen/gogol-gen.cabal
@@ -51,12 +51,13 @@ executable gogol-gen
         , bytestring
         , case-insensitive
         , directory-tree
+        , doclayout
         , ede
         , errors           >= 2.1.2
         , formatting
         , hashable
-        , haskell-src-exts == 1.20.3
-        , hindent          == 5.2.7
+        , haskell-src-exts == 1.23.1
+        , hindent          == 5.3.2
         , lens
         , mtl
         , optparse-applicative

--- a/gen/src/Gen/AST/Flatten.hs
+++ b/gen/src/Gen/AST/Flatten.hs
@@ -25,7 +25,6 @@ import           Control.Monad.Except
 import qualified Data.HashMap.Strict  as Map
 import qualified Data.HashSet         as Set
 import           Data.Maybe
-import           Data.Semigroup       ((<>))
 import           Gen.Formatting
 import           Gen.Types
 import           Prelude              hiding (sum)

--- a/gen/src/Gen/AST/Render.hs
+++ b/gen/src/Gen/AST/Render.hs
@@ -26,7 +26,6 @@ import qualified Data.ByteString.Lazy.Builder as LBB
 import           Data.Char                    (isSpace)
 import qualified Data.HashMap.Strict          as Map
 import           Data.Maybe
-import           Data.Semigroup               ((<>))
 import           Data.String
 import qualified Data.Text.Lazy               as LText
 import qualified Data.Text.Lazy.Encoding      as LText

--- a/gen/src/Gen/AST/Render.hs
+++ b/gen/src/Gen/AST/Render.hs
@@ -22,7 +22,7 @@ import           Control.Applicative
 import           Control.Error
 import           Control.Lens                 hiding (enum, lens)
 import qualified Data.ByteString.Char8        as C8
-import qualified Data.ByteString.Lazy.Builder as LBB
+import qualified Data.ByteString.Builder      as BB
 import           Data.Char                    (isSpace)
 import qualified Data.HashMap.Strict          as Map
 import           Data.Maybe
@@ -174,7 +174,7 @@ pp i x
     | i == Indent = result (HIndent.reformat HIndent.defaultConfig Nothing Nothing p)
     | otherwise   = pure (LText.pack (C8.unpack p))
   where
-    result = hoistEither . bimap (e . LText.pack) (LText.decodeUtf8 . LBB.toLazyByteString)
+    result = hoistEither . bimap (e . LText.pack) (LText.decodeUtf8 . BB.toLazyByteString)
 
     e = flip mappend ("\nSyntax:\n" <> LText.pack (C8.unpack p) <> "\nAST:\n" <> LText.pack (show x))
 

--- a/gen/src/Gen/AST/Solve.hs
+++ b/gen/src/Gen/AST/Solve.hs
@@ -30,7 +30,6 @@ import qualified Data.HashMap.Strict  as Map
 import qualified Data.HashSet         as Set
 import           Data.List            (intersect)
 import           Data.Maybe
-import           Data.Semigroup       ((<>))
 import           Data.Text            (Text)
 import qualified Data.Text            as Text
 import           Data.Text.Manipulate

--- a/gen/src/Gen/IO.hs
+++ b/gen/src/Gen/IO.hs
@@ -24,7 +24,7 @@ import           Gen.Types
 
 import           System.IO
 
-import           UnexceptionalIO           (fromIO, runUIO)
+import qualified UnexceptionalIO           as UIO
 
 import qualified Data.Text                 as Text
 import qualified Data.Text.Lazy            as LText
@@ -36,7 +36,7 @@ run :: ExceptT Error IO a -> IO a
 run = runScript . fmapLT (Text.pack . LText.unpack)
 
 io :: MonadIO m => IO a -> ExceptT Error m a
-io = ExceptT . fmap (first (LText.pack . show)) . liftIO . runUIO . fromIO
+io = ExceptT . fmap (first (LText.pack . show)) . liftIO . UIO.run . UIO.fromIO
 
 title :: MonadIO m => Format (ExceptT Error m ()) a -> a
 title m = runFormat m (io . LText.putStrLn . toLazyText)

--- a/gen/src/Gen/Syntax.hs
+++ b/gen/src/Gen/Syntax.hs
@@ -17,7 +17,6 @@ import           Data.Foldable                (foldl', foldr')
 import qualified Data.HashMap.Strict          as Map
 import           Data.List                    (delete, nub)
 import           Data.Maybe
-import           Data.Semigroup               ((<>))
 import           Data.Text                    (Text)
 import qualified Data.Text                    as Text
 import           Data.Text.Manipulate

--- a/gen/src/Gen/Types.hs
+++ b/gen/src/Gen/Types.hs
@@ -51,7 +51,6 @@ import qualified Data.HashSet               as Set
 import           Data.List                  (sort)
 import           Data.Maybe
 import           Data.Ord
-import           Data.Semigroup             ((<>))
 import           Data.String
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text

--- a/gen/src/Gen/Types/Help.hs
+++ b/gen/src/Gen/Types/Help.hs
@@ -22,7 +22,7 @@ import           Data.Text          (Text)
 import qualified System.IO.Unsafe   as Unsafe
 
 import           Text.Pandoc        as Pandoc
-import           Text.Pandoc.Pretty
+import           Text.DocLayout
 
 import qualified Data.Text          as Text
 

--- a/gen/src/Gen/Types/Schema.hs
+++ b/gen/src/Gen/Types/Schema.hs
@@ -34,7 +34,6 @@ import           Data.Aeson.Types     (Parser)
 import           Data.Function        (on)
 import qualified Data.HashMap.Strict  as Map
 import           Data.Maybe
-import           Data.Semigroup       ((<>))
 import           Data.Text            (Text)
 import qualified Data.Text            as Text
 import           Data.Text.Manipulate

--- a/gen/src/Main.hs
+++ b/gen/src/Main.hs
@@ -18,7 +18,6 @@ import           Control.Error
 import           Control.Lens              hiding ((<.>))
 import           Control.Monad.State
 import           Data.List                 (nub, sort)
-import           Data.Monoid               ((<>))
 import           Data.String
 import qualified Data.Text                 as Text
 import qualified Filesystem                as FS

--- a/gen/stack.yaml
+++ b/gen/stack.yaml
@@ -1,14 +1,14 @@
-resolver: lts-16.31
+resolver: lts-17.12
 
 nix:
   enable: false
-  packages: [zlib, icu]
+  packages: [zlib, icu67]
   add-gc-roots: true
 
 flags: {}
 
 extra-deps:
-  - text-regex-replace-0.1.1.3
+  - text-regex-replace-0.1.1.4
   - ede-0.3.2.0
   - prettyprinter-1.7.0 # for ede-0.3.2.0
   - hindent-5.3.2

--- a/gen/stack.yaml
+++ b/gen/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-13.19
+resolver: lts-16.31
 
 nix:
   enable: false
@@ -9,12 +9,9 @@ flags: {}
 
 extra-deps:
   - text-regex-replace-0.1.1.3
-  - ede-0.2.9
-  - unexceptionalio-0.3.0
-  - github: chrisdone/hindent
-    size: 51114
-    commit: ad0c2a9f8755d37f09b356ab7e45a4e49bcda0b3
-    sha256: 19954fc7dff3d008d9c7688d1c571999c1869f86e5c115aef8b28c2ae622972f
+  - ede-0.3.2.0
+  - prettyprinter-1.7.0 # for ede-0.3.2.0
+  - hindent-5.3.2
 
 packages:
   - "."

--- a/gen/stack.yaml.lock
+++ b/gen/stack.yaml.lock
@@ -5,12 +5,12 @@
 
 packages:
 - completed:
-    hackage: text-regex-replace-0.1.1.3@sha256:e7f612df671c93ced54a3d26528db37852069884e5cb67d5afbb49d3defb5eb9,1627
+    hackage: text-regex-replace-0.1.1.4@sha256:58d96b4e5caec8bf9dd2ca6eaa206fe5bce0fd162759c5e102a92c05f6bd5ebc,1547
     pantry-tree:
       size: 360
-      sha256: 0edba698df19381c1fadb494dfd5278b35b6670bf29cab1a228f2fde9bb9ba89
+      sha256: d7005331a160dffc75bc790a52abb1b68bbdb9dde99c8d4f95ce2edaf70b6385
   original:
-    hackage: text-regex-replace-0.1.1.3
+    hackage: text-regex-replace-0.1.1.4
 - completed:
     hackage: ede-0.3.2.0@sha256:26796d2dfa0979b6ec532dcb113196a1d63edde5553bd019f8d05b52cc966b1a,3790
     pantry-tree:
@@ -34,7 +34,7 @@ packages:
     hackage: hindent-5.3.2
 snapshots:
 - completed:
-    size: 534126
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
-    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
-  original: lts-16.31
+    size: 567669
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/12.yaml
+    sha256: facf6cac73b22a83ca955b580a98a7a09ed71f8f974c7a55d28e608c23e689a9
+  original: lts-17.12

--- a/gen/stack.yaml.lock
+++ b/gen/stack.yaml.lock
@@ -12,38 +12,29 @@ packages:
   original:
     hackage: text-regex-replace-0.1.1.3
 - completed:
-    hackage: ede-0.2.9@sha256:062198b65a661f015bff53c15d53d0b63eac547d44b09d96b7fb8d27752dfc79,3561
+    hackage: ede-0.3.2.0@sha256:26796d2dfa0979b6ec532dcb113196a1d63edde5553bd019f8d05b52cc966b1a,3790
     pantry-tree:
-      size: 5392
-      sha256: ee8d76f8f1ca483f29233498833c7159774efc3c0cb14027703cefac79c41315
+      size: 5398
+      sha256: bd0dbdf4a68c9253417b8201b23c8b62c3d62dd253583e8cd6551f7d4e641961
   original:
-    hackage: ede-0.2.9
+    hackage: ede-0.3.2.0
 - completed:
-    hackage: unexceptionalio-0.3.0@sha256:cd2d74906d336c0a0b827c935d31c39a8504c4414ffc4ab30ccbe22d0ba0cf69,1126
+    hackage: prettyprinter-1.7.0@sha256:6a9569e21fa61163a7f066d23d701e23e917893e8f39733d6e617ec72787ae5f,6007
     pantry-tree:
-      size: 217
-      sha256: 810f5bb08802115d17848c2a8233f95b16f51922edf6850aa663fc1c4067f38a
+      size: 3194
+      sha256: d22f820a1f63497f7fd7e1f04b7d356d92de35582258f6ad55428c88b09e63ff
   original:
-    hackage: unexceptionalio-0.3.0
+    hackage: prettyprinter-1.7.0
 - completed:
-    size: 51114
-    url: https://github.com/chrisdone/hindent/archive/ad0c2a9f8755d37f09b356ab7e45a4e49bcda0b3.tar.gz
-    cabal-file:
-      size: 3452
-      sha256: f3243ef357ed5464c6a5b6f38cbb73a30ec170d1ed0c7beb16c05f5f0ad61833
-    name: hindent
-    version: 5.2.7
-    sha256: 19954fc7dff3d008d9c7688d1c571999c1869f86e5c115aef8b28c2ae622972f
+    hackage: hindent-5.3.2@sha256:070a3622d13e6f0c44d8d189df8f780f61d0b813435a902925ef6d9386b42260,3610
     pantry-tree:
-      size: 1808
-      sha256: 25b9067b3429d448130aa1963527a8442a3f78f9198dc2a0c9b77616d2ede801
+      size: 1027
+      sha256: 36f9c65bbe71c49741c20839606494dacd70c04e0e70649f1da0978aeaf5f77a
   original:
-    size: 51114
-    url: https://github.com/chrisdone/hindent/archive/ad0c2a9f8755d37f09b356ab7e45a4e49bcda0b3.tar.gz
-    sha256: 19954fc7dff3d008d9c7688d1c571999c1869f86e5c115aef8b28c2ae622972f
+    hackage: hindent-5.3.2
 snapshots:
 - completed:
-    size: 498155
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/19.yaml
-    sha256: b9367a80d4393d02e58a46b8a9fdfbd7bc19f59c0c2bbf90034ba15cf52cf213
-  original: lts-13.19
+    size: 534126
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
+    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
+  original: lts-16.31


### PR DESCRIPTION
Hello there! Let's try this again, but this time well-tested, and updated to the last lts.

This makes it easier to build it with a recent nixpkgs.

I also updated the non-stackage dependencies.

The new doclayout dependency was an extracted piece of pandoc we depend on. The rest of the changes are warning squashing.