### PR TITLE
Fix identifier conflict because of mixed case in the api definition

### DIFF
--- a/gen/src/Gen/AST/Solve.hs
+++ b/gen/src/Gen/AST/Solve.hs
@@ -153,10 +153,10 @@ getPrefix g = loc "getPrefix" g $ memo prefixed g go
         pure (Prefix p)
       where
         ls = Map.keys rs
-        ks = Set.fromList (map (CI.mk . local) (ls ++ ["additional" | aps]))
+        ks = Set.fromList (map (CI.mk . renameField . local) (ls ++ ["additional" | aps]))
 
     branch vs = do
-        p <- uniq branches ps (Set.fromList (map CI.mk vs))
+        p <- uniq branches ps (Set.fromList (map (CI.mk . renameField) vs))
         pure (Prefix p)
       where
         ps | any (isDigit . Text.head) vs = acronymPrefixes g


### PR DESCRIPTION
So, I found this bug when trying to build everything with a newer model. It was a fun ride to debug, and I hope the following explanation give a good idea of what's happening here.

This change, along with #159 and #162, are all I needed to be able update the model, regenerate every package, and make sure everything compiles! The only thing left I want to do is see how much I can update the stackage version (and the bounds) for the `gogol` packages. And then I can offer a huge regeneration PR!

----

`getPrefix` is function responsible for giving prefix to record members so that every
single identifier is unique. It does that by looking through a list of candidate prefixes,
and for each, checking that no other record with the same prefix has any field in common.

However, it does that before normalizing the names, so if two names are different, but
get normalized to the same (like `access_token` and `accessToken`), `getPrefix` doesn't catch
it, and we end up with duplicated identifiers in the generated code.

And that's just what happens when you regenerate from the latest model:
in `gogol-shopping-content`, `AccountStatuses.Custombatch` has an `access_token`
 and `AccountCredentials` has `accessToken`. And, because we're unlucky, they both end up
 as `acAccessToken`.

 This commit fixes this by looking ensuring we don't have any duplicates of the normalized names.