### PR TITLE
Remove lenses and use plain field names

### DIFF
--- a/gen/src/Gen/Syntax.hs
+++ b/gen/src/Gen/Syntax.hs
@@ -384,8 +384,7 @@ jsonDecls g p (Map.toList -> rs) = [from', to']
     to' = case rs of
         [(k, v)] | _additional v ->
             InstDecl () Nothing (instrule "ToJSON" (tycon g)) (Just
-                [ funD "toJSON" $
-                    infixApp (var "toJSON") "." (var (fname p k))
+                [ wildcardD "toJSON" g head emptyObj [app (var "toJSON") (var (fname p k))]
                 ])
 
         _                   ->

--- a/gen/src/Gen/Types/Id.hs
+++ b/gen/src/Gen/Types/Id.hs
@@ -109,7 +109,8 @@ cname :: Global -> Name ()
 cname = name
       . Text.unpack
       . renameReserved
-      . lowerHead
+      . mappend "mk"
+      . upperHead
       . Text.dropWhile separator
       . lowerFirstAcronym
       . global
@@ -120,8 +121,11 @@ bname (Prefix p) = name
     . mappend (Text.toUpper p)
     . renameBranch
 
+localName :: Local -> Name ()
+localName = name . Text.unpack . Text.replace "type" "type_" . renameField . local
+
 fname, lname, pname :: Prefix -> Local -> Name ()
-fname = pre (Text.cons '_' . renameField)
+fname _ = localName
 lname = pre renameField
 pname = pre (flip Text.snoc '_' . Text.cons 'p' . upperHead . renameField)
 

--- a/gen/template/_include/prod.ede
+++ b/gen/template/_include/prod.ede
@@ -9,23 +9,9 @@
 {{ type.ctor.help }}
 {% endif %}
 --
-{% for lens in type.lenses %}
-  {% if lens.first %}
--- Use one of the following lenses to modify other fields as desired:
-  {% endif %}
---
--- * '{{ lens.value.name }}'
-{% endfor %}
 {{ type.ctor.sig }}
 {{ type.ctor.decl }}
-{% for lens in type.lenses %}
 
-  {% if lens.value.help %}
-{{ lens.value.help }}
-  {% endif %}
-{{ lens.value.sig }}
-{{ lens.value.decl }}
-{% endfor %}
 {% for class in type.instances %}
 
 {{ class.value }}

--- a/gen/template/action.ede
+++ b/gen/template/action.ede
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE OverloadedStrings  #-}
@@ -28,12 +29,6 @@ module {{ action.ns }}
     , {{ action.type.ctor.name }}
     , {{ action.type.name }}
 
-  {% for lens in action.type.lenses %}
-    {% if lens.first %}
-    -- * Request Lenses
-    {% endif %}
-    , {{ lens.value.name }}
-  {% endfor %}
     ) where
 
 {% for import in moduleImports %}

--- a/gen/template/prod.ede
+++ b/gen/template/prod.ede
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE OverloadedStrings  #-}
 {-# LANGUAGE RecordWildCards    #-}

--- a/gen/template/sum.ede
+++ b/gen/template/sum.ede
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase         #-}
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE OverloadedStrings  #-}

--- a/gen/template/toc.ede
+++ b/gen/template/toc.ede
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TypeOperators     #-}
 
@@ -51,9 +52,6 @@ module {{ moduleName }}
     -- ** {{ schema.value.name }}
     , {{ schema.value.name }}
     , {{ schema.value.ctor.name }}
-      {% for lens in schema.value.lenses %}
-    , {{ lens.value.name }}
-      {% endfor %}
     {% when "sum" %}
 
     -- ** {{ schema.value.name }}

--- a/gen/template/types.ede
+++ b/gen/template/types.ede
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DataKinds          #-}
 {-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE NoImplicitPrelude  #-}
 {-# LANGUAGE OverloadedStrings  #-}
 
@@ -14,7 +15,6 @@ module {{ moduleName }}
       {{ api.url.name }}
   {% for scope in api.scopes %}
     {% if scope.first %}
-
     -- * OAuth Scopes
     {% endif %}
     , {{ scope.value.name }}
@@ -26,9 +26,6 @@ module {{ moduleName }}
     -- * {{ schema.value.name }}
     , {{ schema.value.name }}
     , {{ schema.value.ctor.name }}
-      {% for lens in schema.value.lenses %}
-    , {{ lens.value.name }}
-      {% endfor %}
     {% when "sum" %}
 
     -- * {{ schema.value.name }}


### PR DESCRIPTION
Hi @brendanhay 

I spent a bit of time exploring what it would take to remove lenses from the library and switch to `generic-lens` and friends. Here is the prototype, and the notes I took about the changes. I hope it's interesting to you!

tl;dr: The hard part is to add comments on the record fields, so quite a bit of rewiring might be required to get to a nice state where the fields are documented.

------

Complexities that needed to be addressed:
- Some field names are language reserved name (eg, `type`), and need to be replaced (I went for `type_`)
- The smart constructor often clashes with field names, so I added `mk` to the constructor names
- `DuplicateRecordFields` is needed a lot (though I have not tested if it's needed everywhere)
- Some `toJSON` definition use the field selector, which causes ambiguity. I've rewritten it to use a record wildcard
- The lenses also use field selectors. I removed them instead of fixing them (because that's the point), but nothing prevents us from fixing them instead.

Work that still needs to be done
- Actually removing all the code that make lenses, since it's dead now
- Also, the prefixing code for fields need to be removed.

Now, the actual hard part to figure out:
- Since it's not possible to represent comments in haskell-src-exts types, we can't easily generate a record definition that has the documentation of all the fields (which is kinda needed, since after removing the lenses we don't have the field documentation anymore). So, we would need to refactor things so that the record definition is built in the template rather than as an haskell-src-exts expression.