### PR TITLE
Add support for GKE (kubernetes) service accounts

### DIFF
--- a/gogol/gogol.cabal
+++ b/gogol/gogol.cabal
@@ -45,6 +45,7 @@ library
         , Network.Google.Auth.ApplicationDefault
         , Network.Google.Auth.InstalledApplication
         , Network.Google.Auth.ServiceAccount
+        , Network.Google.Auth.TokenFile
         , Network.Google.Compute.Metadata
         , Network.Google.Env
 

--- a/gogol/src/Network/Google/Auth/TokenFile.hs
+++ b/gogol/src/Network/Google/Auth/TokenFile.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Network.Google.Auth.TokenFile
+-- Copyright   : (c) 2015-2022 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : provisional
+-- Portability : non-portable (GHC extensions)
+--
+module Network.Google.Auth.TokenFile where
+
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import qualified Data.ByteString as ByteString
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text.Encoding
+import qualified Data.Time as Time
+import Network.Google.Internal.Auth
+import Network.Google.Types (AccessToken (..))
+
+serviceAccountTokenFile :: FilePath
+serviceAccountTokenFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+readTokenFile :: MonadIO m => FilePath -> m (OAuthToken s)
+readTokenFile path =
+    liftIO $ do
+        access <- Text.strip . Text.Encoding.decodeUtf8 <$> ByteString.readFile path
+        expiry <- Time.addUTCTime 60 <$> Time.getCurrentTime
+
+        pure OAuthToken
+            { _tokenAccess = AccessToken access
+            , _tokenRefresh = Nothing
+            , _tokenExpiry = expiry
+            }

--- a/gogol/src/Network/Google/Internal/Auth.hs
+++ b/gogol/src/Network/Google/Internal/Auth.hs
@@ -72,6 +72,8 @@ data Credentials (s :: [Symbol])
       -- An 'AuthorizedUser' is typically created by the @gcloud init@ command
       -- of the Google CloudSDK Tools.
 
+    | FromTokenFile !FilePath
+
 {-| Service Account credentials which are typically generated/download
 from the Google Developer console of the following form:
 

--- a/gogol/src/Network/Google/Internal/Logger.hs
+++ b/gogol/src/Network/Google/Internal/Logger.hs
@@ -38,7 +38,7 @@ import qualified Data.ByteString              as BS
 import           Data.ByteString.Builder      (Builder)
 import qualified Data.ByteString.Char8        as BS8
 import qualified Data.ByteString.Lazy         as LBS
-import qualified Data.ByteString.Lazy.Builder as Build
+import qualified Data.ByteString.Builder as Build
 import           Data.CaseInsensitive         (CI)
 import qualified Data.CaseInsensitive         as CI
 import           Data.Int                     (Int16, Int8)

--- a/stack-8.10.7.yaml
+++ b/stack-8.10.7.yaml
@@ -1,4 +1,4 @@
-resolver: lts-17.12
+resolver: lts-18.27
 
 local-bin-path: bin
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-8.10.4.yaml
+stack-8.10.7.yaml

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 567669
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/17/12.yaml
-    sha256: facf6cac73b22a83ca955b580a98a7a09ed71f8f974c7a55d28e608c23e689a9
-  original: lts-17.12
+    size: 590102
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/27.yaml
+    sha256: 79a786674930a89301b0e908fad2822a48882f3d01486117693c377b8edffdbe
+  original: lts-18.27


### PR DESCRIPTION
A quick hack to support GKE workload identity and parity with [kubernetes-client's](https://hackage.haskell.org/package/kubernetes-client-0.3.2.0/docs/src/Kubernetes.Client.Auth.TokenFile.html) default method of in-cluster credentials discovery.