### PR TITLE
use url encoded base64

### DIFF
--- a/lib/gogol-core/src/Gogol/Data/Base64.hs
+++ b/lib/gogol-core/src/Gogol/Data/Base64.hs
@@ -17,7 +17,7 @@ where
 import Control.Lens (Iso', iso)
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Base64 as Base64
+import qualified Data.ByteString.Base64.URL as Base64
 import Data.Hashable
 import qualified Data.Text.Encoding as Text
 import GHC.Generics (Generic)


### PR DESCRIPTION
The `gogol-gmail` library, which is the only gogol library one we're using, is broken due to using `Base64` encoding where it should be using `Base64Url` encodoing. 

This fix made it work on our end, but I suspect it is just shuffling errors around. 