### PR TITLE
Support all services packages in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,14 @@
     outputs = { self, flake-utils, nixpkgs, git-ignore-nix, xmonad }:
   with xmonad.lib;
   let
-    hoverlay = final: prev: hself: hsuper: {
+    servicesFilepath = ./lib/services;
+    serviceNames = builtins.attrNames (builtins.readDir servicesFilepath);
+    mkOverride = hself: serviceName: {
+      name = serviceName;
+      value = hself.callCabal2nix serviceName
+         (git-ignore-nix.lib.gitignoreSource servicesFilepath + ("/" + serviceName)) { };
+    };
+    hoverlay = final: prev: hself: hsuper: (builtins.listToAttrs (map (mkOverride hself) serviceNames)) // {
       gogol = hself.callCabal2nix "gogol"
          (git-ignore-nix.lib.gitignoreSource ./lib/gogol) { };
       gogol-core = hself.callCabal2nix "gogol-core"
@@ -27,6 +34,11 @@
       if builtins.pathExists ./develop.nix
       then import ./develop.nix
       else import ./default-develop.nix;
+    mkPackage = name: {
+      name = name;
+      value = hpkg.${name};
+    };
+    allPackages = serviceNames ++ ["gogol" "gogol-core"];
   in
   rec {
     devShell = hpkg.shellFor (modifyDevShell pkgs {
@@ -35,6 +47,10 @@
         cabal-install
       ];
     });
-    defaultPackage = hpkg.gogol;
-  }) // { inherit hoverlay overlay overlays nixosModule nixosModules; } ;
+    packages = builtins.listToAttrs (map mkPackage allPackages);
+    defaultPackage = self.packages.${system}.gogol;
+  }) // {
+    inherit hoverlay overlay;
+    overlays = { gogol = overlay; };
+  };
 }


### PR DESCRIPTION
This allows ex: `nix build .#gogol-gmail`

note that this causes:

```
❯ nix flake show 
git+file:///home/imalison/Projects/gogol?ref=refs/heads/addRealFlake&rev=09c59df08df2f9de321532dc011b58ce8785dd62
├───defaultPackage
│   ├───aarch64-darwin omitted (use '--all-systems' to show)
│   ├───aarch64-linux omitted (use '--all-systems' to show)
│   ├───i686-linux omitted (use '--all-systems' to show)
│   ├───x86_64-darwin omitted (use '--all-systems' to show)
error:
       … while evaluating the attribute 'defaultPackage'

         at /nix/store/gf87d4imyf2wdmwbbbpnlz65za5xmvnj-source/flake.nix:51:5:

           50|     packages = builtins.listToAttrs (map mkPackage allPackages);
           51|     defaultPackage = self.packages.${system}.gogol;
             |     ^
           52|   }) // { inherit hoverlay overlay overlays; } ;

       … while evaluating the attribute 'packages.x86_64-linux.gogol'

         at /nix/store/gf87d4imyf2wdmwbbbpnlz65za5xmvnj-source/flake.nix:39:7:

           38|       name = name;
           39|       value = hpkg.${name};
             |       ^
           40|     };

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: cannot build '/nix/store/gyl45vl41zwyknsfjparbfxlbknqm5hb-cabal2nix-gogol.drv' during evaluation because the option 'allow-import-from-derivation' is disabled
```

The full output when actually running this is:

https://gist.github.com/IvanMalison/5fa038c506aa66f7507686c56f041d83