### PR TITLE
GHC 9.6 compatability

### DIFF
--- a/lib/gogol/src/Gogol/Auth/ApplicationDefault.hs
+++ b/lib/gogol/src/Gogol/Auth/ApplicationDefault.hs
@@ -18,7 +18,6 @@
 -- /See:/ <https://developers.google.com/identity/protocols/application-default-credentials Application Default Documentation>.
 module Gogol.Auth.ApplicationDefault where
 
-import Control.Applicative
 import Control.Exception.Lens (catching, throwingM)
 import Control.Monad (unless, when)
 import Control.Monad.Catch
@@ -169,7 +168,8 @@ fromJSONCredentials bs = do
         "Failed parsing service_account: " ++ xe
           ++ ", Failed parsing authorized_user: "
           ++ ye
-    _ -> x <|> y
+    (Right a, _) -> Right a
+    (_, Right u) -> Right u
 
 getConfigDirectory :: MonadIO m => m FilePath
 getConfigDirectory = do


### PR DESCRIPTION
GHC 9.6 does not include some instances expected by gogol. Current code fails to compile with the following error (when compiling the `gogol` library):

```
src/Gogol/Auth/ApplicationDefault.hs:172:12: error: [GHC-39999]
    • No instance for ‘Alternative (Either String)’
        arising from a use of ‘<|>’
    • In the expression: x <|> y
      In a case alternative: _ -> x <|> y
      In a stmt of a 'do' block:
        case (x, y) of
          (Left xe, Left ye)
            -> Left
                 $ "Failed parsing service_account: "
                     ++ xe ++ ", Failed parsing authorized_user: " ++ ye
          _ -> x <|> y
    |
172 |     _ -> x <|> y
    |            ^^^
```

This PR fixes the problem.