### PR TITLE
Fix attachment handling in gmail.

### DIFF
--- a/lib/gogol-core/gogol-core.cabal
+++ b/lib/gogol-core/gogol-core.cabal
@@ -36,6 +36,7 @@ library
 
   exposed-modules:
     Gogol.Data.Base64
+    Gogol.Data.Base64Url
     Gogol.Data.JSON
     Gogol.Data.Time
     Gogol.Prelude

--- a/lib/gogol-core/src/Gogol/Data/Base64Url.hs
+++ b/lib/gogol-core/src/Gogol/Data/Base64Url.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+-- |
+-- Module      : Gogol.Data.Base64
+-- Copyright   : (c) 2013-2022 Brendan Hay
+-- License     : Mozilla Public License, v. 2.0.
+-- Maintainer  : Brendan Hay <brendan.g.hay@gmail.com>
+-- Stability   : provisional
+-- Portability : non-portable (GHC extensions)
+module Gogol.Data.Base64Url
+  ( Base64Url (..),
+    _Base64Url,
+  )
+where
+
+import Control.Lens (Iso', iso)
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Base64.Types qualified as Base64
+import Data.ByteString (ByteString)
+import Data.ByteString.Base64.URL qualified as Base64Url
+import Data.Hashable
+import Data.Text.Encoding qualified as Text
+import GHC.Generics (Generic)
+import Gogol.Data.JSON (parseJSONText, toJSONText)
+import Web.HttpApiData (FromHttpApiData (..), ToHttpApiData (..))
+
+-- | Raw bytes that will be transparently base64 encoded\/decoded
+-- on tramission to\/from a remote API.
+newtype Base64Url = Base64Url {fromBase64Url :: ByteString}
+  deriving (Eq, Show, Read, Ord, Generic, Hashable)
+
+_Base64Url :: Iso' Base64Url ByteString
+_Base64Url = iso fromBase64Url Base64Url
+
+instance ToHttpApiData Base64Url where
+  toUrlPiece = Base64.extractBase64 . Base64Url.encodeBase64 . fromBase64Url
+  toQueryParam = Base64.extractBase64 . Base64Url.encodeBase64 . fromBase64Url
+  toHeader = Base64.extractBase64 . Base64Url.encodeBase64' . fromBase64Url
+
+instance FromHttpApiData Base64Url where
+  parseUrlPiece = fmap Base64Url . Base64Url.decodeBase64Untyped . Text.encodeUtf8
+  parseQueryParam = fmap Base64Url . Base64Url.decodeBase64Untyped . Text.encodeUtf8
+  parseHeader = fmap Base64Url . Base64Url.decodeBase64Untyped
+
+instance FromJSON Base64Url where
+  parseJSON = parseJSONText "Base64Url"
+
+instance ToJSON Base64Url where
+  toJSON = toJSONText
+

--- a/lib/gogol-core/src/Gogol/Prelude.hs
+++ b/lib/gogol-core/src/Gogol/Prelude.hs
@@ -25,6 +25,7 @@ import Data.Time as Export (Day, TimeOfDay, UTCTime)
 import Data.Word as Export (Word32, Word64, Word8)
 import GHC.Generics as Export (Generic)
 import Gogol.Data.Base64 as Export
+import Gogol.Data.Base64Url as Export
 import Gogol.Data.JSON as Export
 import Gogol.Data.Time as Export
 import Gogol.Types as Export

--- a/lib/services/gogol-gmail/gen/Gogol/Gmail/Internal/Product.hs
+++ b/lib/services/gogol-gmail/gen/Gogol/Gmail/Internal/Product.hs
@@ -1681,7 +1681,7 @@ data Message = Message
     -- | The parsed email structure in the message parts.
     payload :: (Core.Maybe MessagePart),
     -- | The entire email message in an RFC 2822 formatted and base64url encoded string. Returned in @messages.get@ and @drafts.get@ responses when the @format=RAW@ parameter is supplied.
-    raw :: (Core.Maybe Core.Base64),
+    raw :: (Core.Maybe Core.Base64Url),
     -- | Estimated size in bytes of the message.
     sizeEstimate :: (Core.Maybe Core.Int32),
     -- | A short part of the message text.
@@ -1806,7 +1806,7 @@ data MessagePartBody = MessagePartBody
   { -- | When present, contains the ID of an external attachment that can be retrieved in a separate @messages.attachments.get@ request. When not present, the entire content of the message part body is contained in the data field.
     attachmentId :: (Core.Maybe Core.Text),
     -- | The body data of a MIME message part as a base64url encoded string. May be empty for MIME container types that have no message body or when the body data is sent as a separate attachment. An attachment ID is present if the body data is contained in a separate attachment.
-    data' :: (Core.Maybe Core.Base64),
+    data' :: (Core.Maybe Core.Base64Url),
     -- | Number of bytes for the message part data (encoding notwithstanding).
     size :: (Core.Maybe Core.Int32)
   }
@@ -2190,7 +2190,7 @@ data SmimeInfo = SmimeInfo
     -- | PEM formatted X509 concatenated certificate string (standard base64 encoding). Format used for returning key, which includes public key as well as certificate chain (not private key).
     pem :: (Core.Maybe Core.Text),
     -- | PKCS#12 format containing a single private\/public key pair and certificate chain. This format is only accepted from client for creating a new SmimeInfo and is never returned, because the private key is not intended to be exported. PKCS#12 may be encrypted, in which case encryptedKeyPassword should be set appropriately.
-    pkcs12 :: (Core.Maybe Core.Base64)
+    pkcs12 :: (Core.Maybe Core.Base64Url)
   }
   deriving (Core.Eq, Core.Show, Core.Generic)
 


### PR DESCRIPTION
Use Base64Url encoding for gmail. Currently it uses Base64, which in practice means that it will fail on any email that have attachments.

I patched this way back https://github.com/brendanhay/gogol/pull/182

but this was never merged and likely wrong. This time around I patched it only for gmail.

